### PR TITLE
fix(agfs-shell): handle fd redirection tokens in lexer

### DIFF
--- a/agfs-shell/agfs_shell/lexer.py
+++ b/agfs-shell/agfs_shell/lexer.py
@@ -20,6 +20,10 @@ class TokenType(Enum):
     PIPE = "pipe"
     REDIRECT = "redirect"
     COMMENT = "comment"
+    BACKGROUND = "background"   # & (run in background / pipeline terminator)
+    SEMICOLON = "semicolon"     # ; (statement separator)
+    AND = "and"                 # && (logical AND)
+    OR = "or"                   # || (logical OR)
     EOF = "eof"
 
 
@@ -153,6 +157,36 @@ class ShellLexer:
 
         return ''.join(result)
 
+    def _consume(self) -> str:
+        """Advance one character and return it as a str (empty at EOF)."""
+        ch = self.advance()
+        return ch if ch is not None else ''
+
+    def _consume_fd_dup_suffix(self, redir: str) -> str:
+        """
+        If the next char is '&' followed by digits or '-', consume it as a
+        file-descriptor duplication / close suffix (e.g. '>&1', '2>&1', '>&-').
+
+        Returns the (possibly extended) redirection token.
+        """
+        if self.peek() != '&':
+            return redir
+        # Only treat '&' as a duplication marker when followed by a digit or '-'.
+        # Otherwise '&' belongs to the next token (background, &&, &>).
+        nxt = self.peek(1)
+        if nxt is None or not (nxt.isdigit() or nxt == '-'):
+            return redir
+        redir += self._consume()  # consume '&'
+        # Digits (file descriptor number) or '-' (close fd)
+        if self.peek() == '-':
+            redir += self._consume()
+        else:
+            nxt = self.peek()
+            while nxt is not None and nxt.isdigit():
+                redir += self._consume()
+                nxt = self.peek()
+        return redir
+
     def tokenize(self) -> List[Token]:
         """
         Tokenize the entire input
@@ -180,32 +214,83 @@ class ShellLexer:
                 tokens.append(Token(TokenType.COMMENT, ''.join(comment), start_pos))
                 continue
 
-            # Check for pipe
+            # Logical OR: ||
+            if char == '|' and self.peek(1) == '|':
+                self.advance()
+                self.advance()
+                tokens.append(Token(TokenType.OR, '||', start_pos))
+                continue
+
+            # Pipe: |
             if char == '|':
                 self.advance()
                 tokens.append(Token(TokenType.PIPE, '|', start_pos))
                 continue
 
-            # Check for redirections
-            if char == '>':
-                redir = self.advance()
+            # &> or &>> (redirect both stdout and stderr)
+            if char == '&' and self.peek(1) == '>':
+                redir = self._consume() + self._consume()  # '&>'
                 if self.peek() == '>':
-                    redir += self.advance()
+                    redir += self._consume()  # '&>>'
                 tokens.append(Token(TokenType.REDIRECT, redir, start_pos))
                 continue
 
+            # Logical AND: &&
+            if char == '&' and self.peek(1) == '&':
+                self.advance()
+                self.advance()
+                tokens.append(Token(TokenType.AND, '&&', start_pos))
+                continue
+
+            # Background: &
+            if char == '&':
+                self.advance()
+                tokens.append(Token(TokenType.BACKGROUND, '&', start_pos))
+                continue
+
+            # Statement separator: ;
+            if char == ';':
+                self.advance()
+                tokens.append(Token(TokenType.SEMICOLON, ';', start_pos))
+                continue
+
+            # Output redirection: >, >>, >&N, >&-
+            if char == '>':
+                redir = self._consume()
+                if self.peek() == '>':
+                    redir += self._consume()
+                redir = self._consume_fd_dup_suffix(redir)
+                tokens.append(Token(TokenType.REDIRECT, redir, start_pos))
+                continue
+
+            # Input redirection: <, <<, <&N
             if char == '<':
-                redir = self.advance()
+                redir = self._consume()
                 if self.peek() == '<':
-                    redir += self.advance()
+                    redir += self._consume()
+                redir = self._consume_fd_dup_suffix(redir)
                 tokens.append(Token(TokenType.REDIRECT, redir, start_pos))
                 continue
 
-            if char == '2':
-                if self.peek(1) == '>':
-                    redir = self.advance() + self.advance()
-                    if self.peek() == '>':
-                        redir += self.advance()
+            # FD-prefixed redirection: NUM> NUM>> NUM>&M NUM>&-
+            # Only consume the digit prefix if it is actually followed by a
+            # redirection operator, so plain numeric words still tokenize as WORDs.
+            if char is not None and char.isdigit():
+                # Look past any consecutive digits for '>' or '<'
+                lookahead = 1
+                ahead = self.peek(lookahead)
+                while ahead is not None and ahead.isdigit():
+                    lookahead += 1
+                    ahead = self.peek(lookahead)
+                if self.peek(lookahead) in ('>', '<'):
+                    redir = ''
+                    for _ in range(lookahead):
+                        redir += self._consume()
+                    # Consume operator
+                    redir += self._consume()  # '>' or '<'
+                    if self.peek() == redir[-1]:  # '>>' or '<<'
+                        redir += self._consume()
+                    redir = self._consume_fd_dup_suffix(redir)
                     tokens.append(Token(TokenType.REDIRECT, redir, start_pos))
                     continue
 
@@ -213,6 +298,14 @@ class ShellLexer:
             word = self.read_word()
             if word:
                 tokens.append(Token(TokenType.WORD, word, start_pos))
+                continue
+
+            # Safety net: ensure forward progress so we never loop forever on
+            # an unrecognized character. read_word may stop at a special char
+            # without consuming it; if nothing else advanced pos either, skip
+            # the offending byte rather than spin.
+            if self.pos == start_pos:
+                self.advance()
 
         tokens.append(Token(TokenType.EOF, '', self.pos))
         return tokens

--- a/agfs-shell/tests/test_lexer.py
+++ b/agfs-shell/tests/test_lexer.py
@@ -316,5 +316,209 @@ class TestLexerIntegration:
         assert len(redirect_tokens) >= 1
 
 
+# =============================================================================
+# Regression: lexer infinite-loop on `2>&1` and related operators (dev-2, 2026-05)
+# =============================================================================
+#
+# Before the fix, ShellLexer.tokenize() hung forever on inputs containing
+# bare `&` or `;` (notably `2>&1`): the existing redirection branch consumed
+# `2>` correctly, then `&` fell through to read_word() which terminates on `&`
+# without consuming it, leaving pos unchanged so the outer while-loop spun
+# indefinitely. These tests exercise the new operator handling and a safety
+# net that guarantees forward progress on any unhandled character.
+#
+# All regression tests carry an explicit pytest timeout so a future
+# re-introduction of the hang fails fast instead of stalling CI.
+
+
+def _values(tokens, type_filter=None):
+    """Helper: project tokens to (type, value) tuples, dropping EOF."""
+    if type_filter is None:
+        return [(t.type, t.value) for t in tokens if t.type != TokenType.EOF]
+    return [t.value for t in tokens if t.type == type_filter]
+
+
+class TestLexerHangRegression:
+    """Inputs that used to spin the lexer forever — now must complete promptly."""
+
+    @pytest.mark.timeout(2)
+    def test_2_stderr_to_stdout_does_not_hang(self):
+        toks = ShellLexer("echo hi 2>&1").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "echo"),
+            (TokenType.WORD, "hi"),
+            (TokenType.REDIRECT, "2>&1"),
+        ]
+
+    @pytest.mark.timeout(2)
+    def test_existing_integration_input_does_not_hang(self):
+        # Same input used by TestLexerIntegration.test_command_with_redirects.
+        # Pre-fix, this string caused tokenize() to hang.
+        toks = ShellLexer("command < input.txt > output.txt 2>&1").tokenize()
+        redirects = _values(toks, TokenType.REDIRECT)
+        assert redirects == ["<", ">", "2>&1"]
+
+    @pytest.mark.timeout(2)
+    def test_background_amp_does_not_hang(self):
+        toks = ShellLexer("sleep 5 &").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "sleep"),
+            (TokenType.WORD, "5"),
+            (TokenType.BACKGROUND, "&"),
+        ]
+
+    @pytest.mark.timeout(2)
+    def test_semicolon_separator_does_not_hang(self):
+        toks = ShellLexer("cmd1; cmd2").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "cmd1"),
+            (TokenType.SEMICOLON, ";"),
+            (TokenType.WORD, "cmd2"),
+        ]
+
+    @pytest.mark.timeout(2)
+    def test_pipeline_with_2_stderr_to_stdout(self):
+        toks = ShellLexer("echo a | wc -l 2>&1").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "echo"),
+            (TokenType.WORD, "a"),
+            (TokenType.PIPE, "|"),
+            (TokenType.WORD, "wc"),
+            (TokenType.WORD, "-l"),
+            (TokenType.REDIRECT, "2>&1"),
+        ]
+
+
+class TestFdDuplicationRedirections:
+    """N>&M, N>&-, <&N, &> and &>> should each tokenize as a single REDIRECT."""
+
+    def test_2_to_1_duplication(self):
+        toks = ShellLexer("cmd 2>&1").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["2>&1"]
+
+    def test_1_to_2_duplication(self):
+        toks = ShellLexer("cmd 1>&2").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["1>&2"]
+
+    def test_close_fd_with_dash(self):
+        toks = ShellLexer("cmd 2>&-").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["2>&-"]
+
+    def test_dup_input_fd(self):
+        toks = ShellLexer("cmd <&0").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["<&0"]
+
+    def test_amp_redirect_both_streams(self):
+        toks = ShellLexer("cmd &> out.log").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "cmd"),
+            (TokenType.REDIRECT, "&>"),
+            (TokenType.WORD, "out.log"),
+        ]
+
+    def test_amp_append_both_streams(self):
+        toks = ShellLexer("cmd &>> out.log").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "cmd"),
+            (TokenType.REDIRECT, "&>>"),
+            (TokenType.WORD, "out.log"),
+        ]
+
+    def test_multi_digit_fd_redirection(self):
+        toks = ShellLexer("cmd 10> file").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["10>"]
+
+    def test_2_append_redirection(self):
+        toks = ShellLexer("cmd 2>> err.log").tokenize()
+        assert _values(toks, TokenType.REDIRECT) == ["2>>"]
+
+
+class TestLogicalAndBackgroundOperators:
+    """&&, ||, & (background), ; produce dedicated token types."""
+
+    def test_and_or(self):
+        toks = ShellLexer("cmd1 && cmd2 || cmd3").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "cmd1"),
+            (TokenType.AND, "&&"),
+            (TokenType.WORD, "cmd2"),
+            (TokenType.OR, "||"),
+            (TokenType.WORD, "cmd3"),
+        ]
+
+    def test_background_at_end(self):
+        toks = ShellLexer("sleep 1 &").tokenize()
+        types = [t.type for t in toks if t.type != TokenType.EOF]
+        assert types[-1] == TokenType.BACKGROUND
+
+    def test_semicolon_then_command(self):
+        toks = ShellLexer("a; b; c").tokenize()
+        types = [t.type for t in toks if t.type != TokenType.EOF]
+        assert types == [
+            TokenType.WORD,
+            TokenType.SEMICOLON,
+            TokenType.WORD,
+            TokenType.SEMICOLON,
+            TokenType.WORD,
+        ]
+
+
+class TestQuotesAndPlainNumbers:
+    """Numbers in argument position stay WORDs; quoted operators stay literal."""
+
+    def test_plain_number_is_word(self):
+        toks = ShellLexer("echo 2 ok").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "echo"),
+            (TokenType.WORD, "2"),
+            (TokenType.WORD, "ok"),
+        ]
+
+    def test_quoted_redirection_text_stays_word(self):
+        toks = ShellLexer('echo "keep 2>&1 inside quotes"').tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "echo"),
+            (TokenType.WORD, "keep 2>&1 inside quotes"),
+        ]
+
+    def test_quoted_amp_stays_word(self):
+        toks = ShellLexer("echo 'a && b'").tokenize()
+        assert _values(toks) == [
+            (TokenType.WORD, "echo"),
+            (TokenType.WORD, "a && b"),
+        ]
+
+
+class TestLexerForwardProgress:
+    """Safety-net guarantee: tokenize() must always make forward progress."""
+
+    @pytest.mark.timeout(2)
+    def test_lone_amp_does_not_hang(self):
+        toks = ShellLexer("&").tokenize()
+        assert toks[-1].type == TokenType.EOF
+
+    @pytest.mark.timeout(2)
+    def test_lone_semicolon_does_not_hang(self):
+        toks = ShellLexer(";").tokenize()
+        assert toks[-1].type == TokenType.EOF
+
+    @pytest.mark.timeout(2)
+    def test_empty_input_eof_only(self):
+        toks = ShellLexer("").tokenize()
+        assert [t.type for t in toks] == [TokenType.EOF]
+
+    @pytest.mark.timeout(2)
+    def test_only_whitespace(self):
+        toks = ShellLexer("   \t  ").tokenize()
+        assert [t.type for t in toks] == [TokenType.EOF]
+
+    @pytest.mark.timeout(2)
+    def test_unhandled_chars_do_not_hang(self):
+        # Backticks and other chars without a dedicated handler must still
+        # let the lexer terminate, courtesy of the new safety net.
+        toks = ShellLexer("foo `bar` baz").tokenize()
+        assert toks[-1].type == TokenType.EOF
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary
- fix `ShellLexer.tokenize()` infinite loop on `2>&1`, bare `&`, and `;`
- add token handling for fd duplication redirections, `&>`, `&>>`, `&&`, `||`, background `&`, and semicolon separators
- add lexer regression tests for the original hang path and related operators

## Verification
- Cross-review: PASS by @dev-1 in Slock task #1
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_lexer.py --timeout=10` -> 58 passed
- @dev-1 also reran `tests/test_parser.py tests/test_pipeline.py --timeout=10` -> 16 passed
- `git diff --check 678f51854d2af10fe222d607820a658efdfba049..1c0382965eeebc182d24b89bf8aaf3a115f7fb31` -> clean

## Notes
Parser/runtime semantics for fd duplication and broader process/shell-core failures are tracked separately from this lexer fix.
