### PR TITLE
fix(queuefs): support SQLite queue DDL and regressions

### DIFF
--- a/agfs-server/pkg/plugins/queuefs/backend.go
+++ b/agfs-server/pkg/plugins/queuefs/backend.go
@@ -432,10 +432,7 @@ func (b *TiDBBackend) Dequeue(queueName string) (QueueMessage, bool, error) {
 	var id int64
 	var data string
 
-	querySQL := fmt.Sprintf(
-		"SELECT id, data FROM %s WHERE deleted = 0 ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED",
-		tableName,
-	)
+	querySQL := b.backend.GetDequeueQuery(tableName)
 	err = tx.QueryRow(querySQL).Scan(&id, &data)
 
 	if err == sql.ErrNoRows {
@@ -579,7 +576,7 @@ func (b *TiDBBackend) GetLastEnqueueTime(queueName string) (time.Time, error) {
 
 	var timestamp int64
 	querySQL := fmt.Sprintf(
-		"SELECT MAX(timestamp) FROM %s WHERE deleted = 0",
+		"SELECT COALESCE(MAX(timestamp), 0) FROM %s WHERE deleted = 0",
 		tableName,
 	)
 	err = b.db.QueryRow(querySQL).Scan(&timestamp)
@@ -659,25 +656,21 @@ func (b *TiDBBackend) CreateQueue(queueName string) error {
 	tableName := sanitizeTableName(queueName)
 
 	// Create the queue table
-	createTableSQL := getCreateTableSQL(tableName)
 	skipCreateDDL := false
 	failpoint.Inject("queuefsSkipCreateQueueDDL", func() {
-		// TODO: upstream SQLite queue-table DDL is not yet compatible with the
-		// partial-removal failpoint regression path. This failpoint temporarily
-		// bypasses queue table creation so that the RemoveQueue metadata semantics
-		// can still be covered with a SQLite-backed plugin test. Replace this with
-		// a real SQLite queue-creation path once upstream SQLite support is fixed.
 		skipCreateDDL = true
 	})
 	if !skipCreateDDL {
-		if _, err := b.db.Exec(createTableSQL); err != nil {
-			return fmt.Errorf("failed to create queue table: %w", err)
+		for _, createTableSQL := range b.backend.GetCreateQueueSQL(tableName) {
+			if _, err := b.db.Exec(createTableSQL); err != nil {
+				return fmt.Errorf("failed to create queue table: %w", err)
+			}
 		}
 	}
 
 	// Register in queuefs_registry
 	_, err := b.db.Exec(
-		"INSERT IGNORE INTO queuefs_registry (queue_name, table_name) VALUES (?, ?)",
+		b.backend.GetRegisterQueueSQL(),
 		queueName, tableName,
 	)
 	if err != nil {

--- a/agfs-server/pkg/plugins/queuefs/db_backend.go
+++ b/agfs-server/pkg/plugins/queuefs/db_backend.go
@@ -22,6 +22,15 @@ type DBBackend interface {
 	// GetInitSQL returns the SQL statements to initialize the schema
 	GetInitSQL() []string
 
+	// GetCreateQueueSQL returns the SQL statements to create a queue table.
+	GetCreateQueueSQL(tableName string) []string
+
+	// GetRegisterQueueSQL returns the SQL used to register a queue/table pair.
+	GetRegisterQueueSQL() string
+
+	// GetDequeueQuery returns the SQL used to claim the next queue message.
+	GetDequeueQuery(tableName string) string
+
 	// GetDriverName returns the driver name
 	GetDriverName() string
 }
@@ -56,24 +65,36 @@ func (b *SQLiteDBBackend) Open(cfg map[string]interface{}) (*sql.DB, error) {
 
 func (b *SQLiteDBBackend) GetInitSQL() []string {
 	return []string{
-		// Queue metadata table to track all queues (including empty ones)
-		`CREATE TABLE IF NOT EXISTS queue_metadata (
+		// Queue registry table to track all queues and their backing tables.
+		`CREATE TABLE IF NOT EXISTS queuefs_registry (
 			queue_name TEXT PRIMARY KEY,
-			created_at INTEGER DEFAULT (strftime('%s', 'now')),
-			last_updated INTEGER DEFAULT (strftime('%s', 'now'))
+			table_name TEXT NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
-		// Queue messages table
-		`CREATE TABLE IF NOT EXISTS queue_messages (
+	}
+}
+
+func (b *SQLiteDBBackend) GetCreateQueueSQL(tableName string) []string {
+	return []string{
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			queue_name TEXT NOT NULL,
 			message_id TEXT NOT NULL,
 			data TEXT NOT NULL,
 			timestamp INTEGER NOT NULL,
-			created_at INTEGER DEFAULT (strftime('%s', 'now'))
-		)`,
-		`CREATE INDEX IF NOT EXISTS idx_queue_name ON queue_messages(queue_name)`,
-		`CREATE INDEX IF NOT EXISTS idx_queue_order ON queue_messages(queue_name, id)`,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			deleted INTEGER DEFAULT 0,
+			deleted_at DATETIME
+		)`, tableName),
+		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_%s_deleted_id ON %s (deleted, id)`, tableName, tableName),
 	}
+}
+
+func (b *SQLiteDBBackend) GetRegisterQueueSQL() string {
+	return "INSERT OR IGNORE INTO queuefs_registry (queue_name, table_name) VALUES (?, ?)"
+}
+
+func (b *SQLiteDBBackend) GetDequeueQuery(tableName string) string {
+	return fmt.Sprintf("SELECT id, data FROM %s WHERE deleted = 0 ORDER BY id LIMIT 1", tableName)
 }
 
 // TiDBDBBackend implements DBBackend for TiDB
@@ -210,6 +231,29 @@ func (b *TiDBDBBackend) GetInitSQL() []string {
 	}
 }
 
+func (b *TiDBDBBackend) GetCreateQueueSQL(tableName string) []string {
+	return []string{
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+			id BIGINT AUTO_INCREMENT PRIMARY KEY,
+			message_id VARCHAR(64) NOT NULL,
+			data LONGBLOB NOT NULL,
+			timestamp BIGINT NOT NULL,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			deleted TINYINT(1) DEFAULT 0,
+			deleted_at TIMESTAMP NULL,
+			INDEX idx_deleted_id (deleted, id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`, tableName),
+	}
+}
+
+func (b *TiDBDBBackend) GetRegisterQueueSQL() string {
+	return "INSERT IGNORE INTO queuefs_registry (queue_name, table_name) VALUES (?, ?)"
+}
+
+func (b *TiDBDBBackend) GetDequeueQuery(tableName string) string {
+	return fmt.Sprintf("SELECT id, data FROM %s WHERE deleted = 0 ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED", tableName)
+}
+
 // Helper functions
 
 func extractDatabaseName(dsn string, configDB string) string {
@@ -239,20 +283,6 @@ func sanitizeTableName(queueName string) string {
 
 	// Prefix with queuefs_queue_ to avoid conflicts with system tables
 	return "queuefs_queue_" + tableName
-}
-
-// getCreateTableSQL returns the SQL to create a queue table
-func getCreateTableSQL(tableName string) string {
-	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		id BIGINT AUTO_INCREMENT PRIMARY KEY,
-		message_id VARCHAR(64) NOT NULL,
-		data LONGBLOB NOT NULL,
-		timestamp BIGINT NOT NULL,
-		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-		deleted TINYINT(1) DEFAULT 0,
-		deleted_at TIMESTAMP NULL,
-		INDEX idx_deleted_id (deleted, id)
-	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`, tableName)
 }
 
 // CreateBackend creates the appropriate database backend

--- a/agfs-server/pkg/plugins/queuefs/sqlite_backend_failpoint_test.go
+++ b/agfs-server/pkg/plugins/queuefs/sqlite_backend_failpoint_test.go
@@ -35,33 +35,10 @@ func TestQueueFSSQLiteRemoveQueuePartialFailureRegression(t *testing.T) {
 		t.Fatalf("unexpected backend type %T", plugin.backend)
 	}
 
-	// TODO: upstream SQLite queue creation still does not use a SQLite-compatible
-	// queue-table/registry creation path. Until that is fixed, seed registry/cache
-	// state directly here and keep this test focused on RemoveQueue partial-success
-	// semantics.
-	if _, err := backend.db.Exec(`CREATE TABLE IF NOT EXISTS queuefs_registry (
-		queue_name TEXT PRIMARY KEY,
-		table_name TEXT NOT NULL,
-		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-	)`); err != nil {
-		t.Fatalf("create queuefs_registry: %v", err)
-	}
-	for _, entry := range []struct {
-		queueName string
-		tableName string
-	}{
-		{"jobs", "queuefs_queue_jobs"},
-		{"logs", "queuefs_queue_logs"},
-		{"alerts", "queuefs_queue_alerts"},
-	} {
-		if _, err := backend.db.Exec(
-			"INSERT INTO queuefs_registry (queue_name, table_name) VALUES (?, ?)",
-			entry.queueName,
-			entry.tableName,
-		); err != nil {
-			t.Fatalf("seed queue registry for %s: %v", entry.queueName, err)
+	for _, queueName := range []string{"jobs", "logs", "alerts"} {
+		if err := backend.CreateQueue(queueName); err != nil {
+			t.Fatalf("create queue %s: %v", queueName, err)
 		}
-		backend.tableCache[entry.queueName] = entry.tableName
 	}
 
 	// Inject a DROP TABLE failure on the second removal attempt so the test can

--- a/agfs-server/pkg/plugins/queuefs/sqlite_backend_test.go
+++ b/agfs-server/pkg/plugins/queuefs/sqlite_backend_test.go
@@ -1,0 +1,190 @@
+package queuefs
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+)
+
+func newSQLiteQueueFSTest(t *testing.T) filesystem.FileSystem {
+	t.Helper()
+
+	plugin := NewQueueFSPlugin()
+	if err := plugin.Initialize(map[string]interface{}{
+		"backend": "sqlite",
+		"db_path": filepath.Join(t.TempDir(), "queuefs.db"),
+	}); err != nil {
+		t.Fatalf("initialize sqlite queuefs: %v", err)
+	}
+	t.Cleanup(func() {
+		if plugin.backend != nil {
+			_ = plugin.backend.Close()
+		}
+	})
+
+	return plugin.GetFileSystem()
+}
+
+func readQueueMessage(t *testing.T, fs filesystem.FileSystem, path string) QueueMessage {
+	t.Helper()
+
+	data, err := fs.Read(path, 0, -1)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var msg QueueMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("decode %s response %q: %v", path, string(data), err)
+	}
+	return msg
+}
+
+func readString(t *testing.T, fs filesystem.FileSystem, path string) string {
+	t.Helper()
+
+	data, err := fs.Read(path, 0, -1)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func writeQueueMessage(t *testing.T, fs filesystem.FileSystem, path, value string) {
+	t.Helper()
+
+	if _, err := fs.Write(path, []byte(value), -1, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readDirNames(t *testing.T, fs filesystem.FileSystem, path string) []string {
+	t.Helper()
+
+	entries, err := fs.ReadDir(path)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", path, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func assertNames(t *testing.T, got []string, want ...string) {
+	t.Helper()
+
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("names = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("names = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestQueueFSSQLiteBasicOperations(t *testing.T) {
+	fs := newSQLiteQueueFSTest(t)
+
+	if err := fs.Mkdir("/jobs", 0755); err != nil {
+		t.Fatalf("mkdir /jobs: %v", err)
+	}
+	if _, err := fs.Stat("/jobs"); err != nil {
+		t.Fatalf("stat /jobs: %v", err)
+	}
+
+	writeQueueMessage(t, fs, "/jobs/enqueue", "first")
+	writeQueueMessage(t, fs, "/jobs/enqueue", "second")
+
+	if got := readString(t, fs, "/jobs/size"); got != "2" {
+		t.Fatalf("size after enqueue = %q, want 2", got)
+	}
+
+	if got := readQueueMessage(t, fs, "/jobs/peek"); got.Data != "first" {
+		t.Fatalf("peek data = %q, want first", got.Data)
+	}
+	if got := readString(t, fs, "/jobs/size"); got != "2" {
+		t.Fatalf("size after peek = %q, want 2", got)
+	}
+
+	if got := readQueueMessage(t, fs, "/jobs/dequeue"); got.Data != "first" {
+		t.Fatalf("first dequeue data = %q, want first", got.Data)
+	}
+	if got := readString(t, fs, "/jobs/size"); got != "1" {
+		t.Fatalf("size after first dequeue = %q, want 1", got)
+	}
+	if got := readQueueMessage(t, fs, "/jobs/dequeue"); got.Data != "second" {
+		t.Fatalf("second dequeue data = %q, want second", got.Data)
+	}
+	if got := readString(t, fs, "/jobs/size"); got != "0" {
+		t.Fatalf("size after second dequeue = %q, want 0", got)
+	}
+	if got := readString(t, fs, "/jobs/dequeue"); got != "{}" {
+		t.Fatalf("empty dequeue = %q, want {}", got)
+	}
+
+	writeQueueMessage(t, fs, "/jobs/enqueue", "third")
+	writeQueueMessage(t, fs, "/jobs/enqueue", "fourth")
+	if _, err := fs.Write("/jobs/clear", nil, -1, 0); err != nil {
+		t.Fatalf("clear /jobs: %v", err)
+	}
+	if got := readString(t, fs, "/jobs/size"); got != "0" {
+		t.Fatalf("size after clear = %q, want 0", got)
+	}
+}
+
+func TestQueueFSSQLiteNestedQueuesAndRemoveQueue(t *testing.T) {
+	fs := newSQLiteQueueFSTest(t)
+
+	for _, dir := range []string{"/jobs", "/jobs/high", "/jobs/low", "/logs"} {
+		if err := fs.Mkdir(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeQueueMessage(t, fs, "/jobs/high/enqueue", "urgent")
+	writeQueueMessage(t, fs, "/jobs/low/enqueue", "background")
+	writeQueueMessage(t, fs, "/logs/enqueue", "audit")
+
+	assertNames(t, readDirNames(t, fs, "/"), "README", "jobs", "logs")
+	assertNames(t, readDirNames(t, fs, "/jobs"), "high", "low")
+
+	if err := fs.RemoveAll("/jobs/high"); err != nil {
+		t.Fatalf("remove /jobs/high: %v", err)
+	}
+	if _, err := fs.Stat("/jobs/high"); err == nil {
+		t.Fatal("stat /jobs/high succeeded after removal")
+	}
+	assertNames(t, readDirNames(t, fs, "/jobs"), "low")
+
+	if err := fs.RemoveAll("/jobs"); err != nil {
+		t.Fatalf("remove /jobs: %v", err)
+	}
+	if _, err := fs.Stat("/jobs"); err == nil {
+		t.Fatal("stat /jobs succeeded after subtree removal")
+	}
+	if _, err := fs.Stat("/logs"); err != nil {
+		t.Fatalf("stat /logs after /jobs removal: %v", err)
+	}
+
+	if err := fs.RemoveAll("/"); err != nil {
+		t.Fatalf("remove root queues: %v", err)
+	}
+	assertNames(t, readDirNames(t, fs, "/"), "README")
+}
+
+func TestQueueFSSQLiteRequiresQueueCreation(t *testing.T) {
+	fs := newSQLiteQueueFSTest(t)
+
+	if _, err := fs.Write("/missing/enqueue", []byte("no queue"), -1, filesystem.WriteFlagCreate); err == nil {
+		t.Fatal("write to missing sqlite queue succeeded")
+	}
+}


### PR DESCRIPTION
## Summary
- make QueueFS SQLite initialize the `queuefs_registry` table used by normal queue operations
- split queue table/index/registration SQL by backend so SQLite and TiDB/MySQL each use compatible DDL
- update SQLite failpoint regression to use the public `CreateQueue` path
- add regular SQLite QueueFS regression coverage for basic queue operations, nested queue removal, and writes to missing queues

## Verification
- Cross-review: PASS by @dev-2 in Slock task #5
- `go clean -testcache && go test ./pkg/plugins/queuefs -run 'TestQueueFSSQLite' -v` -> pass
- `go test ./pkg/plugins/queuefs -v` -> pass
- `python3 scripts/run_failpoint_tests.py` -> pass
- `go test ./...` -> pass
- `go test -race ./pkg/plugins/queuefs` -> pass
- `git diff --check origin/master..HEAD` -> clean

## Notes
SQLite multi-consumer dequeue leasing semantics remain out of scope for this patch; use the existing backend choices for multi-writer queue semantics or track a follow-up for SQLite transaction tightening.
