### PR TITLE
fix(agfs-shell): fail fast when webapp dist is missing

### DIFF
--- a/agfs-shell/agfs_shell/webapp_server.py
+++ b/agfs-shell/agfs_shell/webapp_server.py
@@ -16,6 +16,28 @@ except ImportError:
 from .utils.io_wrappers import BufferedTextIO
 
 
+WEBAPP_DIST_DIR = Path(__file__).parent.parent / 'webapp' / 'dist'
+
+
+def validate_webapp_dist(webapp_dir=WEBAPP_DIST_DIR):
+    """Return the built webapp directory or raise an actionable setup error."""
+    index_html = webapp_dir / 'index.html'
+    if index_html.is_file():
+        return webapp_dir
+
+    raise RuntimeError(
+        "Web app build output not found.\n"
+        f"Expected: {index_html}\n\n"
+        "Build the frontend before starting integrated webapp mode:\n"
+        "  cd agfs-shell/webapp\n"
+        "  npm install\n"
+        "  npm run build\n\n"
+        "Or run the setup helper:\n"
+        "  cd agfs-shell/webapp\n"
+        "  ./setup.sh"
+    )
+
+
 class ShellSession:
     """A shell session for a WebSocket connection"""
 
@@ -110,6 +132,7 @@ class WebAppServer:
         self.app = None
         self.runner = None
         self.sessions = {}  # WebSocket sessions
+        self.webapp_dir = validate_webapp_dist()
 
     async def handle_explorer(self, request):
         """Get directory structure for Explorer (optimized API)"""
@@ -495,18 +518,15 @@ class WebAppServer:
 
     async def handle_static(self, request):
         """Serve static files"""
-        # Serve the built React app
-        webapp_dir = Path(__file__).parent.parent / 'webapp' / 'dist'
-
         path = request.match_info.get('path', 'index.html')
         if path == '':
             path = 'index.html'
 
-        file_path = webapp_dir / path
+        file_path = self.webapp_dir / path
 
         # Handle client-side routing - serve index.html for non-existent paths
         if not file_path.exists() or file_path.is_dir():
-            file_path = webapp_dir / 'index.html'
+            file_path = self.webapp_dir / 'index.html'
 
         if file_path.exists() and file_path.is_file():
             return web.FileResponse(file_path)

--- a/agfs-shell/tests/test_webapp_server.py
+++ b/agfs-shell/tests/test_webapp_server.py
@@ -1,0 +1,29 @@
+"""Tests for integrated webapp startup preflight checks."""
+
+import pytest
+
+from agfs_shell.webapp_server import validate_webapp_dist
+
+
+def test_validate_webapp_dist_requires_index_html(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        validate_webapp_dist(dist_dir)
+
+    message = str(exc_info.value)
+    assert "Web app build output not found" in message
+    assert str(dist_dir / "index.html") in message
+    assert "cd agfs-shell/webapp" in message
+    assert "npm install" in message
+    assert "npm run build" in message
+    assert "./setup.sh" in message
+
+
+def test_validate_webapp_dist_accepts_built_webapp(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "index.html").write_text("<!doctype html>", encoding="utf-8")
+
+    assert validate_webapp_dist(dist_dir) == dist_dir


### PR DESCRIPTION
## Summary
- add an integrated webapp startup preflight for `webapp/dist/index.html`
- fail before serving/binding with actionable frontend build commands when the dist output is missing
- keep static serving pointed at the validated dist directory
- add focused tests for missing and present dist output

## Verification
- Cross-review: PASS by @dev-2 in Slock task #12
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_webapp_server.py -v --timeout=15` -> 2 passed
- `PYTHONPATH=. .venv/bin/python -m pytest tests/ --timeout=15 -q` -> 362 passed, 1 xfailed
- `git diff --check origin/master..HEAD` -> clean
