### PR TITLE
fix(agfs-fuse): bound metadata caches and stop cleanup goroutine cleanly

### DIFF
--- a/agfs-fuse/pkg/cache/cache.go
+++ b/agfs-fuse/pkg/cache/cache.go
@@ -1,129 +1,283 @@
 package cache
 
 import (
+	"container/list"
 	"sync"
 	"time"
 
 	agfs "github.com/c4pt0r/agfs/agfs-sdk/go"
 )
 
-// entry represents a cache entry with expiration
+// Option configures a Cache at construction.
+type Option func(*Cache)
+
+// WithMaxEntries bounds the cache to at most n entries. When the limit is
+// reached, least-recently-used entries are evicted to make room for new
+// writes. A value <= 0 disables capacity bounding (backward-compatible
+// default — callers that don't opt in keep the old unbounded behavior).
+//
+// Long-lived mounts should set a finite bound: an unbounded TTL cache can
+// grow without bound between cleanup ticks if the access pattern produces
+// distinct keys faster than they expire.
+func WithMaxEntries(n int) Option {
+	return func(c *Cache) {
+		if n > 0 {
+			c.maxEntries = n
+		}
+	}
+}
+
+// entry represents a cache entry with expiration. The key is duplicated
+// here so eviction can locate the map slot from the list element in O(1).
 type entry struct {
+	key        string
 	value      interface{}
 	expiration time.Time
 }
 
-// isExpired checks if the entry has expired
+// isExpired checks if the entry has expired.
 func (e *entry) isExpired() bool {
 	return time.Now().After(e.expiration)
 }
 
-// Cache is a simple TTL cache
+// Cache is a TTL cache with optional LRU bounding.
+//
+// Concurrency model:
+//   - All mutations and reads (including LRU bookkeeping on Get) take the
+//     write lock, so a single sync.Mutex is sufficient. An RWMutex would
+//     have been wrong because Get must move the element to the front of
+//     the eviction list on hit.
+//   - A background goroutine sweeps expired entries on a ticker. Call
+//     Stop() to terminate it; calling Stop more than once is safe.
+//   - Done() returns a channel that the cleanup goroutine closes as the
+//     last thing it does on its way out. This gives tests (and shutdown
+//     code) a deterministic signal — `<-cache.Done()` — without polling
+//     runtime.NumGoroutine, which is timing-sensitive and flaky.
 type Cache struct {
-	mu      sync.RWMutex
-	entries map[string]*entry
-	ttl     time.Duration
+	mu         sync.Mutex
+	entries    map[string]*list.Element // key -> *list.Element wrapping *entry
+	evictList  *list.List               // doubly-linked list of *entry (front = MRU)
+	ttl        time.Duration
+	maxEntries int           // 0 = unbounded
+	stop       chan struct{} // closed by Stop()
+	stopOnce   sync.Once     // guards Stop()
+	done       chan struct{} // closed by cleanup() when it exits
 }
 
-// NewCache creates a new cache with the given TTL
-func NewCache(ttl time.Duration) *Cache {
+// NewCache creates a cache with the given TTL. Pass WithMaxEntries(...) to
+// bound the cache and enable LRU eviction. Without it, the cache only
+// expires entries via TTL — appropriate for short-lived process scopes
+// but unsafe for long-lived mounts.
+func NewCache(ttl time.Duration, opts ...Option) *Cache {
 	c := &Cache{
-		entries: make(map[string]*entry),
-		ttl:     ttl,
+		entries:   make(map[string]*list.Element),
+		evictList: list.New(),
+		ttl:       ttl,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(c)
 	}
 
-	// Start cleanup goroutine
+	// Start cleanup goroutine. It exits when Stop() closes c.stop and
+	// signals exit by closing c.done.
 	go c.cleanup()
 
 	return c
 }
 
-// Set stores a value in the cache
+// Set stores a value under key. If MaxEntries is set and the cache is at
+// capacity, the least-recently-used entry is evicted first.
 func (c *Cache) Set(key string, value interface{}) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.entries[key] = &entry{
+	if elem, ok := c.entries[key]; ok {
+		// Update existing entry and move to front.
+		ent := elem.Value.(*entry)
+		ent.value = value
+		ent.expiration = time.Now().Add(c.ttl)
+		c.evictList.MoveToFront(elem)
+		return
+	}
+
+	ent := &entry{
+		key:        key,
 		value:      value,
 		expiration: time.Now().Add(c.ttl),
 	}
+	elem := c.evictList.PushFront(ent)
+	c.entries[key] = elem
+
+	// Evict from the back if over capacity.
+	if c.maxEntries > 0 && c.evictList.Len() > c.maxEntries {
+		c.evictOldestLocked()
+	}
 }
 
-// Get retrieves a value from the cache
+// Get retrieves a value under key. A hit moves the entry to the front of
+// the LRU list. Expired entries return (nil, false) and are pruned
+// immediately rather than waiting for the cleanup sweep.
 func (c *Cache) Get(key string) (interface{}, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	e, ok := c.entries[key]
+	elem, ok := c.entries[key]
 	if !ok {
 		return nil, false
 	}
 
-	if e.isExpired() {
+	ent := elem.Value.(*entry)
+	if ent.isExpired() {
+		c.removeElementLocked(elem)
 		return nil, false
 	}
 
-	return e.value, true
+	c.evictList.MoveToFront(elem)
+	return ent.value, true
 }
 
-// Delete removes a value from the cache
+// Delete removes a value from the cache. No-op if absent.
 func (c *Cache) Delete(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	delete(c.entries, key)
+	if elem, ok := c.entries[key]; ok {
+		c.removeElementLocked(elem)
+	}
 }
 
-// DeletePrefix removes all entries with the given prefix
+// DeletePrefix removes all entries with the given prefix.
 func (c *Cache) DeletePrefix(prefix string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// Snapshot keys to remove so we don't mutate the map under iteration.
+	var toRemove []string
 	for key := range c.entries {
 		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
-			delete(c.entries, key)
+			toRemove = append(toRemove, key)
+		}
+	}
+	for _, key := range toRemove {
+		if elem, ok := c.entries[key]; ok {
+			c.removeElementLocked(elem)
 		}
 	}
 }
 
-// Clear removes all entries from the cache
+// Clear removes all entries from the cache. Does not stop the cleanup
+// goroutine — call Stop() for that.
 func (c *Cache) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.entries = make(map[string]*entry)
+	c.entries = make(map[string]*list.Element)
+	c.evictList.Init()
 }
 
-// cleanup periodically removes expired entries
+// Len returns the current number of cached entries (including any that
+// have expired but have not yet been swept).
+func (c *Cache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.evictList.Len()
+}
+
+// Stop terminates the background cleanup goroutine. Calling Stop more
+// than once is safe — subsequent calls are no-ops.
+//
+// Callers should invoke Stop when the cache is no longer needed (for
+// example, from a containing struct's Close method). Otherwise the
+// cleanup goroutine outlives the cache and leaks for the rest of the
+// process lifetime.
+//
+// Stop is non-blocking. To wait for the cleanup goroutine to actually
+// exit (e.g. in tests or strict shutdown ordering), use `<-c.Done()`.
+func (c *Cache) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stop)
+	})
+}
+
+// Done returns a channel that is closed when the cleanup goroutine has
+// exited. Useful for deterministic test shutdown — `<-cache.Done()`
+// returns immediately once the cleanup loop has acknowledged a Stop().
+func (c *Cache) Done() <-chan struct{} {
+	return c.done
+}
+
+// evictOldestLocked drops the LRU entry. Caller must hold c.mu.
+func (c *Cache) evictOldestLocked() {
+	elem := c.evictList.Back()
+	if elem == nil {
+		return
+	}
+	c.removeElementLocked(elem)
+}
+
+// removeElementLocked removes a list element from both the eviction list
+// and the entries map. Caller must hold c.mu.
+func (c *Cache) removeElementLocked(elem *list.Element) {
+	ent := elem.Value.(*entry)
+	c.evictList.Remove(elem)
+	delete(c.entries, ent.key)
+}
+
+// cleanup periodically removes expired entries. Exits when Stop() closes
+// c.stop. Closes c.done as the last thing it does so callers can wait
+// deterministically via Done() rather than poll runtime.NumGoroutine.
 func (c *Cache) cleanup() {
+	defer close(c.done)
+
 	ticker := time.NewTicker(c.ttl)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		c.mu.Lock()
-		now := time.Now()
-		for key, e := range c.entries {
-			if now.After(e.expiration) {
-				delete(c.entries, key)
-			}
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.sweepExpired()
 		}
-		c.mu.Unlock()
 	}
 }
 
-// MetadataCache caches file metadata
+// sweepExpired walks the eviction list once and removes anything past
+// its expiration. Walking front-to-back is fine because TTL is uniform —
+// any traversal order touches every entry.
+func (c *Cache) sweepExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	// Iterate via map keys to avoid mutating list while walking it.
+	var stale []*list.Element
+	for _, elem := range c.entries {
+		if now.After(elem.Value.(*entry).expiration) {
+			stale = append(stale, elem)
+		}
+	}
+	for _, elem := range stale {
+		c.removeElementLocked(elem)
+	}
+}
+
+// MetadataCache caches file metadata.
 type MetadataCache struct {
 	cache *Cache
 }
 
-// NewMetadataCache creates a new metadata cache
-func NewMetadataCache(ttl time.Duration) *MetadataCache {
+// NewMetadataCache creates a new metadata cache. Pass cache.WithMaxEntries
+// to bound it.
+func NewMetadataCache(ttl time.Duration, opts ...Option) *MetadataCache {
 	return &MetadataCache{
-		cache: NewCache(ttl),
+		cache: NewCache(ttl, opts...),
 	}
 }
 
-// Get retrieves file info from cache
+// Get retrieves file info from cache.
 func (mc *MetadataCache) Get(path string) (*agfs.FileInfo, bool) {
 	value, ok := mc.cache.Get(path)
 	if !ok {
@@ -133,39 +287,45 @@ func (mc *MetadataCache) Get(path string) (*agfs.FileInfo, bool) {
 	return info, ok
 }
 
-// Set stores file info in cache
+// Set stores file info in cache.
 func (mc *MetadataCache) Set(path string, info *agfs.FileInfo) {
 	mc.cache.Set(path, info)
 }
 
-// Invalidate removes file info from cache
+// Invalidate removes file info from cache.
 func (mc *MetadataCache) Invalidate(path string) {
 	mc.cache.Delete(path)
 }
 
-// InvalidatePrefix invalidates all paths with the given prefix
+// InvalidatePrefix invalidates all paths with the given prefix.
 func (mc *MetadataCache) InvalidatePrefix(prefix string) {
 	mc.cache.DeletePrefix(prefix)
 }
 
-// Clear clears all cached metadata
+// Clear clears all cached metadata.
 func (mc *MetadataCache) Clear() {
 	mc.cache.Clear()
 }
 
-// DirectoryCache caches directory listings
+// Stop terminates the background cleanup goroutine. Idempotent.
+func (mc *MetadataCache) Stop() {
+	mc.cache.Stop()
+}
+
+// DirectoryCache caches directory listings.
 type DirectoryCache struct {
 	cache *Cache
 }
 
-// NewDirectoryCache creates a new directory cache
-func NewDirectoryCache(ttl time.Duration) *DirectoryCache {
+// NewDirectoryCache creates a new directory cache. Pass cache.WithMaxEntries
+// to bound it.
+func NewDirectoryCache(ttl time.Duration, opts ...Option) *DirectoryCache {
 	return &DirectoryCache{
-		cache: NewCache(ttl),
+		cache: NewCache(ttl, opts...),
 	}
 }
 
-// Get retrieves directory listing from cache
+// Get retrieves directory listing from cache.
 func (dc *DirectoryCache) Get(path string) ([]agfs.FileInfo, bool) {
 	value, ok := dc.cache.Get(path)
 	if !ok {
@@ -175,22 +335,27 @@ func (dc *DirectoryCache) Get(path string) ([]agfs.FileInfo, bool) {
 	return files, ok
 }
 
-// Set stores directory listing in cache
+// Set stores directory listing in cache.
 func (dc *DirectoryCache) Set(path string, files []agfs.FileInfo) {
 	dc.cache.Set(path, files)
 }
 
-// Invalidate removes directory listing from cache
+// Invalidate removes directory listing from cache.
 func (dc *DirectoryCache) Invalidate(path string) {
 	dc.cache.Delete(path)
 }
 
-// InvalidatePrefix invalidates all directories with the given prefix
+// InvalidatePrefix invalidates all directories with the given prefix.
 func (dc *DirectoryCache) InvalidatePrefix(prefix string) {
 	dc.cache.DeletePrefix(prefix)
 }
 
-// Clear clears all cached directories
+// Clear clears all cached directories.
 func (dc *DirectoryCache) Clear() {
 	dc.cache.Clear()
+}
+
+// Stop terminates the background cleanup goroutine. Idempotent.
+func (dc *DirectoryCache) Stop() {
+	dc.cache.Stop()
 }

--- a/agfs-fuse/pkg/cache/cache_test.go
+++ b/agfs-fuse/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -151,4 +152,153 @@ func TestCacheConcurrency(t *testing.T) {
 	<-done
 
 	// If we got here without panic, concurrency is safe
+}
+
+// TestCacheLRUEviction verifies that bounding the cache via WithMaxEntries
+// evicts the least-recently-used entry on overflow and that a Get on an
+// older entry moves it back to the front of the eviction order.
+func TestCacheLRUEviction(t *testing.T) {
+	c := NewCache(1*time.Second, WithMaxEntries(2))
+	defer c.Stop()
+
+	c.Set("a", 1)
+	c.Set("b", 2)
+
+	// Touching "a" should make "b" the LRU.
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected a to be present")
+	}
+
+	// "c" forces eviction; "b" was LRU after touching "a".
+	c.Set("c", 3)
+
+	if _, ok := c.Get("b"); ok {
+		t.Error("expected b to be evicted as LRU")
+	}
+	if _, ok := c.Get("a"); !ok {
+		t.Error("expected a to survive eviction")
+	}
+	if _, ok := c.Get("c"); !ok {
+		t.Error("expected c to be present")
+	}
+	if got, want := c.Len(), 2; got != want {
+		t.Errorf("Len() = %d, want %d", got, want)
+	}
+}
+
+// TestCacheLRUDoesNotEvictWithoutLimit confirms the legacy unbounded
+// constructor path: callers who skip WithMaxEntries still see no
+// eviction (only TTL expiry).
+func TestCacheLRUDoesNotEvictWithoutLimit(t *testing.T) {
+	c := NewCache(10 * time.Second)
+	defer c.Stop()
+
+	for i := 0; i < 100; i++ {
+		c.Set(string(rune('a'+i%26))+string(rune('0'+i/26)), i)
+	}
+	if got, want := c.Len(), 100; got != want {
+		t.Errorf("unbounded cache Len() = %d, want %d", got, want)
+	}
+}
+
+// TestCacheUpdateInPlaceDoesNotEvict checks that updating an existing
+// key does not count as a new insertion for capacity purposes — the
+// fixed-size cache should never evict a still-present key just because
+// it was rewritten.
+func TestCacheUpdateInPlaceDoesNotEvict(t *testing.T) {
+	c := NewCache(1*time.Second, WithMaxEntries(2))
+	defer c.Stop()
+
+	c.Set("a", 1)
+	c.Set("b", 2)
+	c.Set("a", 99) // update in place, not a new entry
+
+	if got, ok := c.Get("a"); !ok || got != 99 {
+		t.Errorf("Get(a) = (%v, %v), want (99, true)", got, ok)
+	}
+	if _, ok := c.Get("b"); !ok {
+		t.Error("b should still be present after a was updated in place")
+	}
+}
+
+// TestCacheStopExitsCleanupGoroutine verifies the deterministic shutdown
+// contract: after Stop, Done() closes promptly. Avoids
+// runtime.NumGoroutine polling (timing-sensitive).
+func TestCacheStopExitsCleanupGoroutine(t *testing.T) {
+	c := NewCache(50 * time.Millisecond)
+
+	c.Stop()
+
+	select {
+	case <-c.Done():
+		// success — cleanup goroutine acknowledged the stop
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup goroutine did not exit within 2s of Stop()")
+	}
+}
+
+// TestCacheStopIdempotent guarantees Stop can be called many times — and
+// from multiple goroutines — without panic. Critical because containing
+// structs (FUSE filesystem, etc.) may call Close multiple times during
+// shutdown ordering.
+func TestCacheStopIdempotent(t *testing.T) {
+	c := NewCache(50 * time.Millisecond)
+
+	const N = 8
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Stop()
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-c.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done did not close after concurrent Stop() calls")
+	}
+}
+
+// TestCacheExpiredEntryReturnsNotFound verifies an expired-but-not-swept
+// entry returns (nil, false) from Get and is pruned immediately — this
+// matters because the sweeper runs on a ticker, so a Get between ticks
+// must still observe the expiration boundary.
+func TestCacheExpiredEntryReturnsNotFound(t *testing.T) {
+	c := NewCache(10 * time.Millisecond)
+	defer c.Stop()
+
+	c.Set("k", "v")
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := c.Get("k"); ok {
+		t.Error("expected expired entry to be reported as not found")
+	}
+	if got := c.Len(); got != 0 {
+		t.Errorf("expected expired entry to be pruned, Len() = %d", got)
+	}
+}
+
+// TestMetadataCacheStop / TestDirectoryCacheStop verify that the wrapper
+// types thread Stop through to the underlying Cache.
+func TestMetadataCacheStop(t *testing.T) {
+	mc := NewMetadataCache(50 * time.Millisecond)
+	mc.Stop()
+	select {
+	case <-mc.cache.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("metadata cache cleanup goroutine did not exit")
+	}
+}
+
+func TestDirectoryCacheStop(t *testing.T) {
+	dc := NewDirectoryCache(50 * time.Millisecond)
+	dc.Stop()
+	select {
+	case <-dc.cache.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("directory cache cleanup goroutine did not exit")
+	}
 }

--- a/agfs-fuse/pkg/fusefs/fs.go
+++ b/agfs-fuse/pkg/fusefs/fs.go
@@ -30,7 +30,25 @@ type Config struct {
 	ServerURL string
 	CacheTTL  time.Duration
 	Debug     bool
+
+	// MetaCacheMaxEntries caps the metadata cache size. <= 0 falls back to
+	// defaultMetaCacheMaxEntries; an unbounded cache is not exposed via this
+	// constructor to prevent OOM on long-lived mounts. Override only with
+	// good reason.
+	MetaCacheMaxEntries int
+
+	// DirCacheMaxEntries caps the directory-listing cache size. <= 0 falls
+	// back to defaultDirCacheMaxEntries.
+	DirCacheMaxEntries int
 }
+
+// Conservative defaults; large enough that interactive workloads almost
+// never hit the cap, small enough that the absolute memory footprint of
+// the metadata caches stays bounded for long-lived mounts.
+const (
+	defaultMetaCacheMaxEntries = 50_000
+	defaultDirCacheMaxEntries  = 5_000
+)
 
 // NewAGFSFS creates a new AGFS FUSE filesystem
 func NewAGFSFS(config Config) *AGFSFS {
@@ -40,11 +58,20 @@ func NewAGFSFS(config Config) *AGFSFS {
 	}
 	client := agfs.NewClientWithHTTPClient(config.ServerURL, httpClient)
 
+	metaMax := config.MetaCacheMaxEntries
+	if metaMax <= 0 {
+		metaMax = defaultMetaCacheMaxEntries
+	}
+	dirMax := config.DirCacheMaxEntries
+	if dirMax <= 0 {
+		dirMax = defaultDirCacheMaxEntries
+	}
+
 	return &AGFSFS{
 		client:    client,
 		handles:   NewHandleManager(client),
-		metaCache: cache.NewMetadataCache(config.CacheTTL),
-		dirCache:  cache.NewDirectoryCache(config.CacheTTL),
+		metaCache: cache.NewMetadataCache(config.CacheTTL, cache.WithMaxEntries(metaMax)),
+		dirCache:  cache.NewDirectoryCache(config.CacheTTL, cache.WithMaxEntries(dirMax)),
 		cacheTTL:  config.CacheTTL,
 	}
 }
@@ -52,15 +79,17 @@ func NewAGFSFS(config Config) *AGFSFS {
 // Close closes the filesystem and releases resources
 func (root *AGFSFS) Close() error {
 	// Close all open handles
-	if err := root.handles.CloseAll(); err != nil {
-		return err
-	}
+	closeErr := root.handles.CloseAll()
 
-	// Clear caches
+	// Clear caches and stop their cleanup goroutines so the filesystem
+	// shuts down cleanly without leaking goroutines for the rest of the
+	// process lifetime.
 	root.metaCache.Clear()
 	root.dirCache.Clear()
+	root.metaCache.Stop()
+	root.dirCache.Stop()
 
-	return nil
+	return closeErr
 }
 
 // Statfs returns filesystem statistics


### PR DESCRIPTION
## Summary
- add optional LRU entry bounds to the FUSE cache package
- add deterministic `Stop()` / `Done()` shutdown for cache cleanup goroutines
- wire bounded metadata and directory cache defaults into `AGFSFS`
- stop cache cleanup goroutines during filesystem close

## Verification
- Cross-review: PASS by @dev-1 in Slock task #14
- `go test ./pkg/cache -v -timeout 30s` -> 14 PASS
- `go test ./... -timeout 60s` -> pass
- `go test -race ./pkg/cache -timeout 30s` -> pass
- `git diff --check origin/master..HEAD` -> clean

## Notes
Cache caps are configurable through `fusefs.Config`; CLI flags for runtime tuning are a non-blocking follow-up if operators need them.
