### PR TITLE
fix(sqlfs2): harden dynamic SQL identifiers

### DIFF
--- a/agfs-server/pkg/plugins/sqlfs2/backend_mysql.go
+++ b/agfs-server/pkg/plugins/sqlfs2/backend_mysql.go
@@ -51,8 +51,12 @@ func (b *MySQLBackend) GetTableSchema(db *sql.DB, dbName, tableName string) (str
 	}
 
 	var tblName, createTableStmt string
-	query := fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)
-	err := db.QueryRow(query).Scan(&tblName, &createTableStmt)
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return "", err
+	}
+	query := fmt.Sprintf("SHOW CREATE TABLE %s", quotedTable)
+	err = db.QueryRow(query).Scan(&tblName, &createTableStmt)
 	if err != nil {
 		return "", fmt.Errorf("failed to get table schema: %w", err)
 	}
@@ -104,7 +108,11 @@ func (b *MySQLBackend) SwitchDatabase(db *sql.DB, dbName string) error {
 	if dbName == "" {
 		return nil
 	}
-	_, err := db.Exec(fmt.Sprintf("USE `%s`", dbName))
+	quotedDB, err := quoteSQLIdentifier("database", dbName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(fmt.Sprintf("USE %s", quotedDB))
 	if err != nil {
 		return fmt.Errorf("failed to switch to database %s: %w", dbName, err)
 	}
@@ -119,7 +127,11 @@ func (b *MySQLBackend) GetTableColumns(db *sql.DB, dbName, tableName string) ([]
 		}
 	}
 
-	query := fmt.Sprintf("SHOW COLUMNS FROM `%s`", tableName)
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf("SHOW COLUMNS FROM %s", quotedTable)
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get table columns: %w", err)

--- a/agfs-server/pkg/plugins/sqlfs2/backend_sqlite.go
+++ b/agfs-server/pkg/plugins/sqlfs2/backend_sqlite.go
@@ -25,6 +25,9 @@ func (b *SQLiteBackend) Initialize(cfg map[string]interface{}) (*sql.DB, error) 
 }
 
 func (b *SQLiteBackend) GetTableSchema(db *sql.DB, dbName, tableName string) (string, error) {
+	if err := validateSQLIdentifier("table", tableName); err != nil {
+		return "", err
+	}
 	var createTableStmt string
 	query := "SELECT sql FROM sqlite_master WHERE type='table' AND name=?"
 	err := db.QueryRow(query, tableName).Scan(&createTableStmt)
@@ -63,7 +66,11 @@ func (b *SQLiteBackend) SwitchDatabase(db *sql.DB, dbName string) error {
 }
 
 func (b *SQLiteBackend) GetTableColumns(db *sql.DB, dbName, tableName string) ([]ColumnInfo, error) {
-	query := fmt.Sprintf("PRAGMA table_info(%s)", tableName)
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf("PRAGMA table_info(%s)", quotedTable)
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get table columns: %w", err)

--- a/agfs-server/pkg/plugins/sqlfs2/backend_tidb.go
+++ b/agfs-server/pkg/plugins/sqlfs2/backend_tidb.go
@@ -118,7 +118,12 @@ func (b *TiDBBackend) Initialize(cfg map[string]interface{}) (*sql.DB, error) {
 			if err == nil {
 				defer tempDB.Close()
 				// Try to create database if it doesn't exist
-				_, err = tempDB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", dbName))
+				quotedDB, quoteErr := quoteSQLIdentifier("database", dbName)
+				if quoteErr != nil {
+					err = quoteErr
+				} else {
+					_, err = tempDB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quotedDB))
+				}
 				if err != nil {
 					log.Warnf("[sqlfs2] Failed to create database '%s': %v", dbName, err)
 				}
@@ -153,8 +158,12 @@ func (b *TiDBBackend) GetTableSchema(db *sql.DB, dbName, tableName string) (stri
 	}
 
 	var tblName, createTableStmt string
-	query := fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)
-	err := db.QueryRow(query).Scan(&tblName, &createTableStmt)
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return "", err
+	}
+	query := fmt.Sprintf("SHOW CREATE TABLE %s", quotedTable)
+	err = db.QueryRow(query).Scan(&tblName, &createTableStmt)
 	if err != nil {
 		return "", fmt.Errorf("failed to get table schema: %w", err)
 	}
@@ -206,7 +215,11 @@ func (b *TiDBBackend) SwitchDatabase(db *sql.DB, dbName string) error {
 	if dbName == "" {
 		return nil
 	}
-	_, err := db.Exec(fmt.Sprintf("USE `%s`", dbName))
+	quotedDB, err := quoteSQLIdentifier("database", dbName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(fmt.Sprintf("USE %s", quotedDB))
 	if err != nil {
 		return fmt.Errorf("failed to switch to database %s: %w", dbName, err)
 	}
@@ -221,7 +234,11 @@ func (b *TiDBBackend) GetTableColumns(db *sql.DB, dbName, tableName string) ([]C
 		}
 	}
 
-	query := fmt.Sprintf("SHOW COLUMNS FROM `%s`", tableName)
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf("SHOW COLUMNS FROM %s", quotedTable)
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get table columns: %w", err)

--- a/agfs-server/pkg/plugins/sqlfs2/identifiers.go
+++ b/agfs-server/pkg/plugins/sqlfs2/identifiers.go
@@ -1,0 +1,101 @@
+package sqlfs2
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var sqlIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+const sqlIdentifierRule = "must match [A-Za-z_][A-Za-z0-9_]*"
+
+func validateSQLIdentifier(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid SQL %s identifier %q: must not be empty", kind, name)
+	}
+	if !sqlIdentifierPattern.MatchString(name) {
+		return fmt.Errorf("invalid SQL %s identifier %q: %s", kind, name, sqlIdentifierRule)
+	}
+	return nil
+}
+
+func quoteSQLIdentifier(kind, name string) (string, error) {
+	if err := validateSQLIdentifier(kind, name); err != nil {
+		return "", err
+	}
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`", nil
+}
+
+func qualifiedTableName(dbName, tableName string) (string, error) {
+	quotedDB, err := quoteSQLIdentifier("database", dbName)
+	if err != nil {
+		return "", err
+	}
+	quotedTable, err := quoteSQLIdentifier("table", tableName)
+	if err != nil {
+		return "", err
+	}
+	return quotedDB + "." + quotedTable, nil
+}
+
+func countTableSQL(dbName, tableName string) (string, error) {
+	table, err := qualifiedTableName(dbName, tableName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("SELECT COUNT(*) FROM %s", table), nil
+}
+
+func dropTableSQL(dbName, tableName string) (string, error) {
+	table, err := qualifiedTableName(dbName, tableName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", table), nil
+}
+
+func dropDatabaseSQL(backend Backend, dbName string) (string, error) {
+	if backend != nil && backend.Name() == "sqlite" {
+		return "", fmt.Errorf("drop database is not supported for sqlite backend")
+	}
+	quotedDB, err := quoteSQLIdentifier("database", dbName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("DROP DATABASE IF EXISTS %s", quotedDB), nil
+}
+
+func quotedColumnNames(columnNames []string) ([]string, error) {
+	quotedColumns := make([]string, len(columnNames))
+	for i, colName := range columnNames {
+		quoted, err := quoteSQLIdentifier("column", colName)
+		if err != nil {
+			return nil, err
+		}
+		quotedColumns[i] = quoted
+	}
+	return quotedColumns, nil
+}
+
+func insertRowsSQL(dbName, tableName string, columnNames []string) (string, error) {
+	if len(columnNames) == 0 {
+		return "", fmt.Errorf("columnNames must not be empty")
+	}
+	table, err := qualifiedTableName(dbName, tableName)
+	if err != nil {
+		return "", err
+	}
+	quotedColumns, err := quotedColumnNames(columnNames)
+	if err != nil {
+		return "", err
+	}
+	placeholders := make([]string, len(columnNames))
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+		table,
+		strings.Join(quotedColumns, ", "),
+		strings.Join(placeholders, ", ")), nil
+}

--- a/agfs-server/pkg/plugins/sqlfs2/identifiers_test.go
+++ b/agfs-server/pkg/plugins/sqlfs2/identifiers_test.go
@@ -1,0 +1,151 @@
+package sqlfs2
+
+import (
+	"database/sql"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+)
+
+func newSQLiteSQLFS2ForTest(t *testing.T) (*SQLFS2Plugin, *sqlfs2FS) {
+	t.Helper()
+
+	plugin := NewSQLFS2Plugin()
+	err := plugin.Initialize(map[string]interface{}{
+		"backend": "sqlite",
+		"db_path": filepath.Join(t.TempDir(), "sqlfs2.db"),
+	})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := plugin.Shutdown(); err != nil {
+			t.Fatalf("Shutdown() error = %v", err)
+		}
+	})
+
+	fs, ok := plugin.GetFileSystem().(*sqlfs2FS)
+	if !ok {
+		t.Fatalf("GetFileSystem() returned %T, want *sqlfs2FS", plugin.GetFileSystem())
+	}
+	return plugin, fs
+}
+
+func mustExecSQL(t *testing.T, db *sql.DB, stmt string, args ...interface{}) {
+	t.Helper()
+	if _, err := db.Exec(stmt, args...); err != nil {
+		t.Fatalf("Exec(%q) error = %v", stmt, err)
+	}
+}
+
+func tableExistsInSQLite(t *testing.T, db *sql.DB, tableName string) bool {
+	t.Helper()
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", tableName).Scan(&count)
+	if err != nil {
+		t.Fatalf("table existence query error = %v", err)
+	}
+	return count > 0
+}
+
+func requireInvalidIdentifierError(t *testing.T, err error, wantKind string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected invalid identifier error, got nil")
+	}
+	if !errors.Is(err, filesystem.ErrInvalidArgument) {
+		t.Fatalf("expected filesystem.ErrInvalidArgument, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "invalid SQL "+wantKind+" identifier") {
+		t.Fatalf("expected invalid SQL %s identifier error, got %v", wantKind, err)
+	}
+}
+
+func TestSQLFS2IdentifierSQLBuilders(t *testing.T) {
+	dropSQL, err := dropTableSQL("main", "users")
+	if err != nil {
+		t.Fatalf("dropTableSQL() error = %v", err)
+	}
+	if want := "DROP TABLE IF EXISTS `main`.`users`"; dropSQL != want {
+		t.Fatalf("dropTableSQL() = %q, want %q", dropSQL, want)
+	}
+
+	insertSQL, err := insertRowsSQL("main", "users", []string{"id", "user_name"})
+	if err != nil {
+		t.Fatalf("insertRowsSQL() error = %v", err)
+	}
+	if want := "INSERT INTO `main`.`users` (`id`, `user_name`) VALUES (?, ?)"; insertSQL != want {
+		t.Fatalf("insertRowsSQL() = %q, want %q", insertSQL, want)
+	}
+
+	if _, err := dropTableSQL("main", "users; DROP TABLE safe"); err == nil {
+		t.Fatal("dropTableSQL() accepted hostile table identifier")
+	}
+	if _, err := insertRowsSQL("main", "users", []string{"id", "name; DROP TABLE safe"}); err == nil {
+		t.Fatal("insertRowsSQL() accepted hostile column identifier")
+	}
+}
+
+func TestSQLFS2SQLiteCountAndDropTableUseValidatedQuotedIdentifiers(t *testing.T) {
+	plugin, fs := newSQLiteSQLFS2ForTest(t)
+	mustExecSQL(t, plugin.db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExecSQL(t, plugin.db, "INSERT INTO users (name) VALUES (?), (?)", "Alice", "Bob")
+
+	data, err := fs.Read("/main/users/count", 0, -1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("Read(count) error = %v", err)
+	}
+	if string(data) != "2\n" {
+		t.Fatalf("Read(count) = %q, want %q", data, "2\n")
+	}
+
+	if err := fs.RemoveAll("/main/users"); err != nil {
+		t.Fatalf("RemoveAll(table) error = %v", err)
+	}
+	if tableExistsInSQLite(t, plugin.db, "users") {
+		t.Fatal("users table still exists after RemoveAll")
+	}
+}
+
+func TestSQLFS2RejectsHostilePathIdentifiersBeforeSQL(t *testing.T) {
+	plugin, fs := newSQLiteSQLFS2ForTest(t)
+	mustExecSQL(t, plugin.db, "CREATE TABLE safe (id INTEGER)")
+
+	_, err := fs.Read("/main/safe; DROP TABLE safe/count", 0, -1)
+	requireInvalidIdentifierError(t, err, "table")
+	if !tableExistsInSQLite(t, plugin.db, "safe") {
+		t.Fatal("safe table was dropped after hostile count path")
+	}
+
+	err = fs.RemoveAll("/main; DROP DATABASE main/safe")
+	requireInvalidIdentifierError(t, err, "database")
+	if !tableExistsInSQLite(t, plugin.db, "safe") {
+		t.Fatal("safe table was dropped after hostile database path")
+	}
+
+	err = fs.RemoveAll("/main/safe; DROP TABLE safe")
+	requireInvalidIdentifierError(t, err, "table")
+	if !tableExistsInSQLite(t, plugin.db, "safe") {
+		t.Fatal("safe table was dropped after hostile drop-table path")
+	}
+}
+
+func TestSQLFS2SQLiteDropDatabaseIsExplicitlyUnsupported(t *testing.T) {
+	plugin, fs := newSQLiteSQLFS2ForTest(t)
+	mustExecSQL(t, plugin.db, "CREATE TABLE safe (id INTEGER)")
+
+	err := fs.RemoveAll("/main")
+	if err == nil {
+		t.Fatal("RemoveAll(/main) unexpectedly succeeded on sqlite backend")
+	}
+	if !strings.Contains(err.Error(), "drop database is not supported for sqlite backend") {
+		t.Fatalf("RemoveAll(/main) error = %v, want sqlite unsupported error", err)
+	}
+	if !tableExistsInSQLite(t, plugin.db, "safe") {
+		t.Fatal("safe table was dropped after sqlite database remove")
+	}
+}

--- a/agfs-server/pkg/plugins/sqlfs2/sqlfs2.go
+++ b/agfs-server/pkg/plugins/sqlfs2/sqlfs2.go
@@ -22,13 +22,13 @@ const (
 
 // Session represents a Plan 9 style session for SQL operations
 type Session struct {
-	id         int64            // Numeric session ID
+	id         int64 // Numeric session ID
 	dbName     string
 	tableName  string
-	tx         *sql.Tx          // SQL transaction
-	result     []byte           // Query result (JSON)
-	lastError  string           // Error message
-	lastAccess time.Time        // Last access time
+	tx         *sql.Tx   // SQL transaction
+	result     []byte    // Query result (JSON)
+	lastError  string    // Error message
+	lastAccess time.Time // Last access time
 	mu         sync.Mutex
 }
 
@@ -438,26 +438,48 @@ func isDatabaseLevelFile(name string) bool {
 	return name == "ctl"
 }
 
+func validatePathSQLIdentifier(kind, name string) error {
+	if err := validateSQLIdentifier(kind, name); err != nil {
+		return filesystem.NewInvalidArgumentError(kind, name, err.Error())
+	}
+	return nil
+}
+
+func validatePathSQLIdentifiers(dbName, tableName string) error {
+	if dbName != "" {
+		if err := validatePathSQLIdentifier("database", dbName); err != nil {
+			return err
+		}
+	}
+	if tableName != "" {
+		if err := validatePathSQLIdentifier("table", tableName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // parsePath parses a path into (dbName, tableName, sid, operation)
 // Supported paths:
-//   /                              -> ("", "", "", "")
-//   /ctl                           -> ("", "", "", "ctl") - root level ctl
-//   /<sid>                         -> ("", "", sid, "")   - root level session
-//   /<sid>/query                   -> ("", "", sid, "query")
-//   /dbName                        -> (dbName, "", "", "")
-//   /dbName/ctl                    -> (dbName, "", "", "ctl") - database level ctl
-//   /dbName/<sid>                  -> (dbName, "", sid, "") - database level session
-//   /dbName/<sid>/query            -> (dbName, "", sid, "query") - database level session file
-//   /dbName/tableName              -> (dbName, tableName, "", "")
-//   /dbName/tableName/ctl          -> (dbName, tableName, "", "ctl")
-//   /dbName/tableName/schema       -> (dbName, tableName, "", "schema")
-//   /dbName/tableName/count        -> (dbName, tableName, "", "count")
-//   /dbName/tableName/<sid>        -> (dbName, tableName, sid, "")
-//   /dbName/tableName/<sid>/query  -> (dbName, tableName, sid, "query")
-//   /dbName/tableName/<sid>/result -> (dbName, tableName, sid, "result")
-//   /dbName/tableName/<sid>/ctl    -> (dbName, tableName, sid, "ctl")
-//   /dbName/tableName/<sid>/data   -> (dbName, tableName, sid, "data")
-//   /dbName/tableName/<sid>/error  -> (dbName, tableName, sid, "error")
+//
+//	/                              -> ("", "", "", "")
+//	/ctl                           -> ("", "", "", "ctl") - root level ctl
+//	/<sid>                         -> ("", "", sid, "")   - root level session
+//	/<sid>/query                   -> ("", "", sid, "query")
+//	/dbName                        -> (dbName, "", "", "")
+//	/dbName/ctl                    -> (dbName, "", "", "ctl") - database level ctl
+//	/dbName/<sid>                  -> (dbName, "", sid, "") - database level session
+//	/dbName/<sid>/query            -> (dbName, "", sid, "query") - database level session file
+//	/dbName/tableName              -> (dbName, tableName, "", "")
+//	/dbName/tableName/ctl          -> (dbName, tableName, "", "ctl")
+//	/dbName/tableName/schema       -> (dbName, tableName, "", "schema")
+//	/dbName/tableName/count        -> (dbName, tableName, "", "count")
+//	/dbName/tableName/<sid>        -> (dbName, tableName, sid, "")
+//	/dbName/tableName/<sid>/query  -> (dbName, tableName, sid, "query")
+//	/dbName/tableName/<sid>/result -> (dbName, tableName, sid, "result")
+//	/dbName/tableName/<sid>/ctl    -> (dbName, tableName, sid, "ctl")
+//	/dbName/tableName/<sid>/data   -> (dbName, tableName, sid, "data")
+//	/dbName/tableName/<sid>/error  -> (dbName, tableName, sid, "error")
 func (fs *sqlfs2FS) parsePath(path string) (dbName, tableName, sid, operation string, err error) {
 	path = strings.TrimPrefix(path, "/")
 	parts := strings.Split(path, "/")
@@ -479,7 +501,11 @@ func (fs *sqlfs2FS) parsePath(path string) (dbName, tableName, sid, operation st
 			return "", "", parts[0], "", nil
 		}
 		// Database level: /dbName
-		return parts[0], "", "", "", nil
+		dbName := parts[0]
+		if err := validatePathSQLIdentifiers(dbName, ""); err != nil {
+			return "", "", "", "", err
+		}
+		return dbName, "", "", "", nil
 	}
 
 	if len(parts) == 2 {
@@ -493,14 +519,26 @@ func (fs *sqlfs2FS) parsePath(path string) (dbName, tableName, sid, operation st
 		}
 		if isDatabaseLevelFile(parts[1]) {
 			// Database level ctl: /dbName/ctl
-			return parts[0], "", "", parts[1], nil
+			dbName := parts[0]
+			if err := validatePathSQLIdentifiers(dbName, ""); err != nil {
+				return "", "", "", "", err
+			}
+			return dbName, "", "", parts[1], nil
 		}
 		if isSessionID(parts[1]) {
 			// Database level session: /dbName/<sid>
-			return parts[0], "", parts[1], "", nil
+			dbName := parts[0]
+			if err := validatePathSQLIdentifiers(dbName, ""); err != nil {
+				return "", "", "", "", err
+			}
+			return dbName, "", parts[1], "", nil
 		}
 		// Table level: /dbName/tableName
-		return parts[0], parts[1], "", "", nil
+		dbName, tableName := parts[0], parts[1]
+		if err := validatePathSQLIdentifiers(dbName, tableName); err != nil {
+			return "", "", "", "", err
+		}
+		return dbName, tableName, "", "", nil
 	}
 
 	if len(parts) == 3 {
@@ -512,13 +550,25 @@ func (fs *sqlfs2FS) parsePath(path string) (dbName, tableName, sid, operation st
 		// - /dbName/tableName/<sid> -> session directory
 		if isSessionID(parts[1]) && isSessionFile(parts[2]) {
 			// Database level session file: /dbName/<sid>/query
-			return parts[0], "", parts[1], parts[2], nil
+			dbName := parts[0]
+			if err := validatePathSQLIdentifiers(dbName, ""); err != nil {
+				return "", "", "", "", err
+			}
+			return dbName, "", parts[1], parts[2], nil
 		}
 		if isTableLevelFile(parts[2]) {
-			return parts[0], parts[1], "", parts[2], nil
+			dbName, tableName := parts[0], parts[1]
+			if err := validatePathSQLIdentifiers(dbName, tableName); err != nil {
+				return "", "", "", "", err
+			}
+			return dbName, tableName, "", parts[2], nil
 		}
 		if isSessionID(parts[2]) {
-			return parts[0], parts[1], parts[2], "", nil
+			dbName, tableName := parts[0], parts[1]
+			if err := validatePathSQLIdentifiers(dbName, tableName); err != nil {
+				return "", "", "", "", err
+			}
+			return dbName, tableName, parts[2], "", nil
 		}
 		return "", "", "", "", filesystem.NewNotFoundError("stat", path)
 	}
@@ -528,7 +578,11 @@ func (fs *sqlfs2FS) parsePath(path string) (dbName, tableName, sid, operation st
 		if !isSessionID(parts[2]) {
 			return "", "", "", "", filesystem.NewNotFoundError("stat", path)
 		}
-		return parts[0], parts[1], parts[2], parts[3], nil
+		dbName, tableName := parts[0], parts[1]
+		if err := validatePathSQLIdentifiers(dbName, tableName); err != nil {
+			return "", "", "", "", err
+		}
+		return dbName, tableName, parts[2], parts[3], nil
 	}
 
 	return "", "", "", "", filesystem.NewNotFoundError("stat", path)
@@ -743,9 +797,12 @@ func (fs *sqlfs2FS) Read(path string, offset int64, size int64) ([]byte, error) 
 				return nil, err
 			}
 
-			sqlStmt := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s", dbName, tableName)
+			sqlStmt, err := countTableSQL(dbName, tableName)
+			if err != nil {
+				return nil, err
+			}
 			var count int64
-			err := fs.plugin.db.QueryRow(sqlStmt).Scan(&count)
+			err = fs.plugin.db.QueryRow(sqlStmt).Scan(&count)
 			if err != nil {
 				return nil, fmt.Errorf("count query error: %w", err)
 			}
@@ -1321,15 +1378,12 @@ func (fs *sqlfs2FS) Write(path string, data []byte, offset int64, flags filesyst
 				}
 			}
 
-			placeholders := make([]string, len(columnNames))
-			for i := range placeholders {
-				placeholders[i] = "?"
+			insertSQL, err := insertRowsSQL(dbName, tableName, columnNames)
+			if err != nil {
+				session.lastError = err.Error()
+				session.result = nil
+				return 0, err
 			}
-
-			insertSQL := fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES (%s)",
-				dbName, tableName,
-				strings.Join(columnNames, ", "),
-				strings.Join(placeholders, ", "))
 
 			if _, err := session.tx.Exec(insertSQL, values...); err != nil {
 				session.lastError = fmt.Sprintf("insert error at record %d: %v", idx+1, err)
@@ -1394,8 +1448,11 @@ func (fs *sqlfs2FS) RemoveAll(path string) error {
 	// Path should be /dbName
 	if dbName != "" && tableName == "" && sid == "" && operation == "" {
 		// Execute DROP DATABASE
-		sqlStmt := fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName)
-		_, err := fs.plugin.db.Exec(sqlStmt)
+		sqlStmt, err := dropDatabaseSQL(fs.plugin.backend, dbName)
+		if err != nil {
+			return err
+		}
+		_, err = fs.plugin.db.Exec(sqlStmt)
 		if err != nil {
 			return fmt.Errorf("failed to drop database: %w", err)
 		}
@@ -1413,8 +1470,11 @@ func (fs *sqlfs2FS) RemoveAll(path string) error {
 		}
 
 		// Execute DROP TABLE
-		sqlStmt := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, tableName)
-		_, err := fs.plugin.db.Exec(sqlStmt)
+		sqlStmt, err := dropTableSQL(dbName, tableName)
+		if err != nil {
+			return err
+		}
+		_, err = fs.plugin.db.Exec(sqlStmt)
 		if err != nil {
 			return fmt.Errorf("failed to drop table: %w", err)
 		}
@@ -2239,9 +2299,11 @@ func (h *SQLFileHandle) populateReadBuffer() error {
 			return fmt.Errorf("invalid path for count")
 		}
 		// Use transaction for count query
-		sqlStmt := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s", h.dbName, h.tableName)
+		sqlStmt, err := countTableSQL(h.dbName, h.tableName)
+		if err != nil {
+			return err
+		}
 		var count int64
-		var err error
 		if h.tx != nil {
 			err = h.tx.QueryRow(sqlStmt).Scan(&count)
 		} else {
@@ -2593,15 +2655,10 @@ func (h *SQLFileHandle) executeInsertJSON(data string) error {
 			}
 		}
 
-		placeholders := make([]string, len(columnNames))
-		for i := range placeholders {
-			placeholders[i] = "?"
+		insertSQL, err := insertRowsSQL(h.dbName, h.tableName, columnNames)
+		if err != nil {
+			return err
 		}
-
-		insertSQL := fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES (%s)",
-			h.dbName, h.tableName,
-			strings.Join(columnNames, ", "),
-			strings.Join(placeholders, ", "))
 
 		if _, err := h.tx.Exec(insertSQL, values...); err != nil {
 			return fmt.Errorf("insert error at record %d: %w", idx+1, err)


### PR DESCRIPTION
## Summary
- add a strict SQLFS2 path identifier contract for generated SQL identifiers
- centralize quoted SQL builders for qualified table names, count, drop-table, drop-database, and JSON insert statements
- reject malformed/hostile database/table path components before SQL is built
- make SQLite drop-database explicitly unsupported instead of emitting invalid SQL
- add SQLite regressions for valid count/drop-table behavior, hostile path identifiers, and safe SQLite drop-database rejection

## Verification
- Cross-review: PASS by @dev-2 in Slock task #9
- `go test ./pkg/plugins/sqlfs2 -v -timeout 60s` -> pass
- `go test ./... -timeout 300s` -> pass
- `git diff --check origin/master..HEAD` -> clean

## Notes
This hardens SQLFS2-generated SQL paths. User-supplied SQL written to session `query` files is intentionally still executed as SQL by design and remains out of scope.
