### PR TITLE
fix(agfs-sdk): bound streaming reads with progress timeouts

### DIFF
--- a/agfs-sdk/go/client.go
+++ b/agfs-sdk/go/client.go
@@ -2,12 +2,14 @@ package agfs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -17,10 +19,18 @@ var (
 	ErrNotSupported = fmt.Errorf("operation not supported")
 )
 
+// DefaultStreamingProgressTimeout is the default per-chunk inactivity
+// bound applied to streaming reads (ReadStream, ReadHandleStream). It
+// caps how long the client will wait between bytes arriving from the
+// server, without capping total stream duration. Override on a Client
+// via SetStreamingProgressTimeout; pass <=0 to disable.
+const DefaultStreamingProgressTimeout = 60 * time.Second
+
 // Client is a Go client for AGFS HTTP API
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL                  string
+	httpClient               *http.Client
+	streamingProgressTimeout time.Duration
 }
 
 // NewClient creates a new AGFS client
@@ -33,15 +43,119 @@ func NewClient(baseURL string) *Client {
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		streamingProgressTimeout: DefaultStreamingProgressTimeout,
 	}
 }
 
 // NewClientWithHTTPClient creates a new AGFS client with custom HTTP client
 func NewClientWithHTTPClient(baseURL string, httpClient *http.Client) *Client {
 	return &Client{
-		baseURL:    normalizeBaseURL(baseURL),
-		httpClient: httpClient,
+		baseURL:                  normalizeBaseURL(baseURL),
+		httpClient:               httpClient,
+		streamingProgressTimeout: DefaultStreamingProgressTimeout,
 	}
+}
+
+// SetStreamingProgressTimeout configures the per-chunk inactivity
+// timeout for streaming reads (ReadStream, ReadHandleStream). A value
+// of <=0 disables the bound and restores the pre-2026-05 behaviour
+// where a stalled server can hang the client indefinitely — only set
+// that explicitly for callers who know they're tolerant to such hangs
+// (e.g. interactive use with a hard ^C).
+//
+// The bound applies *between* bytes arriving on the wire, not to the
+// total stream duration; long streams that keep making progress are
+// unaffected.
+func (c *Client) SetStreamingProgressTimeout(d time.Duration) {
+	c.streamingProgressTimeout = d
+}
+
+// progressReader wraps an http.Response body with an inactivity
+// timeout. Each successful Read signals progress; if no progress
+// arrives within `timeout`, the request context is canceled, which
+// closes the underlying connection and causes the next Read to return
+// an error.
+//
+// When timeout is <= 0 the watchdog goroutine is not started and the
+// reader behaves as a pure passthrough (apart from canceling the
+// request context on Close to free resources).
+type progressReader struct {
+	body      io.ReadCloser
+	cancel    context.CancelFunc
+	progress  chan struct{}
+	done      chan struct{}
+	timeout   time.Duration
+	closeOnce sync.Once
+}
+
+func newProgressReader(body io.ReadCloser, cancel context.CancelFunc, timeout time.Duration) *progressReader {
+	pr := &progressReader{
+		body:    body,
+		cancel:  cancel,
+		timeout: timeout,
+	}
+	if timeout > 0 {
+		pr.progress = make(chan struct{}, 1)
+		pr.done = make(chan struct{})
+		go pr.watchdog()
+	}
+	return pr
+}
+
+func (pr *progressReader) watchdog() {
+	timer := time.NewTimer(pr.timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-pr.progress:
+			// Drain a previously-fired tick before resetting, per the
+			// time.Timer.Reset documentation contract.
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(pr.timeout)
+		case <-timer.C:
+			// No progress within timeout. Cancel the request context —
+			// the in-flight Read on body will surface an error so the
+			// caller observes the timeout.
+			pr.cancel()
+			return
+		case <-pr.done:
+			return
+		}
+	}
+}
+
+// Read forwards to the underlying body and signals progress to the
+// watchdog on any non-zero read.
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.body.Read(p)
+	if n > 0 && pr.progress != nil {
+		// Non-blocking send: drop the signal if the watchdog hasn't
+		// drained the previous one yet. The watchdog only needs to know
+		// that progress is happening, not its rate.
+		select {
+		case pr.progress <- struct{}{}:
+		default:
+		}
+	}
+	return n, err
+}
+
+// Close releases the body and cancels the request context. Safe to
+// call multiple times.
+func (pr *progressReader) Close() error {
+	pr.closeOnce.Do(func() {
+		if pr.done != nil {
+			close(pr.done)
+		}
+		pr.cancel()
+	})
+	return pr.body.Close()
 }
 
 // normalizeBaseURL ensures the base URL ends with /api/v1
@@ -532,31 +646,42 @@ func (c *Client) GetCapabilities() (*CapabilitiesResponse, error) {
 	return &caps, nil
 }
 
-// ReadStream opens a streaming connection to read from a file
-// Returns an io.ReadCloser that streams data from the server
-// The caller is responsible for closing the reader
+// ReadStream opens a streaming connection to read from a file.
+// Returns an io.ReadCloser that streams data from the server. The
+// caller is responsible for closing the reader.
+//
+// The total stream is intentionally not bounded by an http.Client
+// Timeout (which would kill long but well-behaved streams). The
+// returned reader does enforce a per-chunk *inactivity* timeout
+// controlled by Client.SetStreamingProgressTimeout (default 60s) — a
+// server that goes silent mid-stream surfaces a Read error rather than
+// hanging the caller indefinitely.
 func (c *Client) ReadStream(path string) (io.ReadCloser, error) {
 	query := url.Values{}
 	query.Set("path", path)
 	query.Set("stream", "true") // Enable streaming mode
 
-	// Create request with no timeout for streaming
-	streamClient := &http.Client{
-		Timeout: 0, // No timeout for streaming
-	}
+	// No overall request timeout — per-chunk inactivity is bounded by
+	// the progressReader wrapper below.
+	streamClient := &http.Client{Timeout: 0}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	reqURL := fmt.Sprintf("%s/files?%s", c.baseURL, query.Encode())
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	resp, err := streamClient.Do(req)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		cancel()
 		defer resp.Body.Close()
 		var errResp ErrorResponse
 		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
@@ -565,9 +690,10 @@ func (c *Client) ReadStream(path string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
 	}
 
-	// Return the response body as a ReadCloser
-	// Caller must close it when done
-	return resp.Body, nil
+	// Wrap with a progress watchdog. When the configured timeout is
+	// <=0, the wrapper is a passthrough that still cancels the request
+	// context on Close so HTTP resources are released cleanly.
+	return newProgressReader(resp.Body, cancel, c.streamingProgressTimeout), nil
 }
 
 // GrepRequest represents a grep search request
@@ -770,29 +896,34 @@ func (c *Client) ReadHandle(handleID int64, offset int64, size int) ([]byte, err
 	return data, nil
 }
 
-// ReadHandleStream opens a streaming connection to read from a file handle
-// Returns an io.ReadCloser that streams data from the server
-// The caller is responsible for closing the reader
+// ReadHandleStream opens a streaming connection to read from a file
+// handle. Returns an io.ReadCloser that streams data from the server;
+// the caller is responsible for closing it.
+//
+// Like ReadStream, the returned reader applies a per-chunk inactivity
+// timeout (Client.SetStreamingProgressTimeout, default 60s) so a
+// stalled server cannot wedge the caller indefinitely.
 func (c *Client) ReadHandleStream(handleID int64) (io.ReadCloser, error) {
 	endpoint := fmt.Sprintf("/handles/%d/stream", handleID)
 
-	// Create request with no timeout for streaming
-	streamClient := &http.Client{
-		Timeout: 0, // No timeout for streaming
-	}
+	streamClient := &http.Client{Timeout: 0}
+	ctx, cancel := context.WithCancel(context.Background())
 
 	reqURL := fmt.Sprintf("%s%s", c.baseURL, endpoint)
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	resp, err := streamClient.Do(req)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		cancel()
 		defer resp.Body.Close()
 		var errResp ErrorResponse
 		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
@@ -801,7 +932,7 @@ func (c *Client) ReadHandleStream(handleID int64) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, errResp.Error)
 	}
 
-	return resp.Body, nil
+	return newProgressReader(resp.Body, cancel, c.streamingProgressTimeout), nil
 }
 
 // WriteHandle writes data to a file handle

--- a/agfs-sdk/go/streaming_progress_timeout_test.go
+++ b/agfs-sdk/go/streaming_progress_timeout_test.go
@@ -1,0 +1,171 @@
+package agfs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStreamingProgressTimeout_FiresOnStalledServer verifies that
+// ReadStream surfaces an error when the server stops sending bytes for
+// longer than the configured progress timeout. Without the timeout,
+// the same scenario would hang indefinitely.
+func TestStreamingProgressTimeout_FiresOnStalledServer(t *testing.T) {
+	// Flush headers, then hold the body open until the request context
+	// is canceled OR a long sentinel fires. Tying the hold to
+	// r.Context().Done() lets httptest.Server.Close() finish promptly
+	// when our progressReader cancels the request; the long sentinel
+	// makes the test deterministic if cancellation ever regresses.
+	const stall = 3 * time.Second
+	stalled := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(stall):
+		}
+	}))
+	defer stalled.Close()
+
+	client := NewClient(stalled.URL)
+	client.SetStreamingProgressTimeout(300 * time.Millisecond)
+
+	rc, err := client.ReadStream("/anything")
+	if err != nil {
+		t.Fatalf("ReadStream failed early: %v", err)
+	}
+	defer rc.Close()
+
+	start := time.Now()
+	buf := make([]byte, 1024)
+	var readErr error
+	for {
+		_, readErr = rc.Read(buf)
+		if readErr != nil {
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	if readErr == nil || readErr == io.EOF {
+		t.Fatalf("expected non-EOF error from stalled stream, got %v", readErr)
+	}
+	// We expect the underlying connection to fail (context canceled
+	// closes the conn). The exact error wording depends on the Go
+	// version's net/http, so match on a coarse fingerprint.
+	msg := readErr.Error()
+	if !strings.Contains(msg, "context canceled") &&
+		!strings.Contains(msg, "use of closed network connection") &&
+		!strings.Contains(msg, "EOF") {
+		t.Fatalf("unexpected error from stalled stream: %v", readErr)
+	}
+	// Sanity: we waited about the configured progress timeout, not the
+	// server's full stall window.
+	if elapsed >= stall {
+		t.Fatalf("progress timeout did not fire — waited %s (stall was %s)", elapsed, stall)
+	}
+}
+
+// TestStreamingProgressTimeout_PassesThroughWhenDisabled ensures the
+// pre-2026-05 behavior (no progress bound) is preserved for callers
+// who explicitly opt out via SetStreamingProgressTimeout(0).
+func TestStreamingProgressTimeout_PassesThroughWhenDisabled(t *testing.T) {
+	// Send headers, then a small payload after a deliberate gap. With
+	// the timeout disabled, the gap should not fail the read.
+	gap := 250 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(gap)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	// Disable the progress timeout entirely.
+	client.SetStreamingProgressTimeout(0)
+
+	rc, err := client.ReadStream("/anything")
+	if err != nil {
+		t.Fatalf("ReadStream failed early: %v", err)
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll failed with progress-timeout disabled: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("ReadAll returned %q, want %q", data, "hello")
+	}
+}
+
+// TestStreamingProgressTimeout_ProgressKeepsAlive shows that a stream
+// making steady progress doesn't trip the per-chunk timeout even when
+// each chunk takes longer than the timeout would have allowed if
+// applied to the whole stream.
+func TestStreamingProgressTimeout_ProgressKeepsAlive(t *testing.T) {
+	chunkInterval := 200 * time.Millisecond
+	chunks := 3
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("ResponseWriter does not implement http.Flusher")
+		}
+		for i := 0; i < chunks; i++ {
+			time.Sleep(chunkInterval)
+			_, _ = w.Write([]byte("chunk-"))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	// Per-chunk bound is generous relative to each gap but much tighter
+	// than the cumulative stream duration.
+	client.SetStreamingProgressTimeout(500 * time.Millisecond)
+
+	rc, err := client.ReadStream("/anything")
+	if err != nil {
+		t.Fatalf("ReadStream failed early: %v", err)
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll failed mid-stream: %v", err)
+	}
+	want := strings.Repeat("chunk-", chunks)
+	if string(data) != want {
+		t.Fatalf("got %q, want %q", data, want)
+	}
+}
+
+// TestStreamingProgressTimeout_DefaultIsSet pins the default to the
+// declared constant, in case a future refactor accidentally drops the
+// initialization in NewClient.
+func TestStreamingProgressTimeout_DefaultIsSet(t *testing.T) {
+	c := NewClient("http://example.invalid")
+	if c.streamingProgressTimeout != DefaultStreamingProgressTimeout {
+		t.Fatalf("default streamingProgressTimeout = %s, want %s",
+			c.streamingProgressTimeout, DefaultStreamingProgressTimeout)
+	}
+
+	c2 := NewClientWithHTTPClient("http://example.invalid", &http.Client{})
+	if c2.streamingProgressTimeout != DefaultStreamingProgressTimeout {
+		t.Fatalf("NewClientWithHTTPClient default streamingProgressTimeout = %s, want %s",
+			c2.streamingProgressTimeout, DefaultStreamingProgressTimeout)
+	}
+}

--- a/agfs-sdk/python/pyagfs/client.py
+++ b/agfs-sdk/python/pyagfs/client.py
@@ -11,7 +11,19 @@ from .exceptions import AGFSClientError, AGFSNotSupportedError
 class AGFSClient:
     """Client for interacting with AGFS (Plugin-based File System) Server API"""
 
-    def __init__(self, api_base_url="http://localhost:8080", timeout=10):
+    #: Default per-chunk progress timeout (seconds) for streaming reads and
+    #: writes. Long-running streams used to disable timeouts entirely
+    #: (``timeout=None``), which let a stalled server wedge the client
+    #: indefinitely. This bounds *inter-chunk* idle time without bounding
+    #: total request duration.
+    DEFAULT_STREAMING_PROGRESS_TIMEOUT = 60
+
+    def __init__(
+        self,
+        api_base_url="http://localhost:8080",
+        timeout=10,
+        streaming_progress_timeout=DEFAULT_STREAMING_PROGRESS_TIMEOUT,
+    ):
         """
         Initialize AGFS client.
 
@@ -19,7 +31,17 @@ class AGFSClient:
             api_base_url: API base URL. Can be either full URL with "/api/v1" or just the base.
                          If "/api/v1" is not present, it will be automatically appended.
                          e.g., "http://localhost:8080" or "http://localhost:8080/api/v1"
-            timeout: Request timeout in seconds (default: 10)
+            timeout: Request timeout in seconds for non-streaming requests
+                (default: 10). For streaming endpoints, see
+                ``streaming_progress_timeout`` — this value only applies
+                to the connect phase of the request.
+            streaming_progress_timeout: Per-chunk progress timeout in
+                seconds for streaming endpoints (default: 60). The total
+                stream may run as long as needed, but a server that
+                stops sending bytes for this long will trigger a
+                :class:`requests.exceptions.ReadTimeout`. Set to ``None``
+                to opt out (matches pre-2026-05 behaviour); not
+                recommended for unattended agents.
         """
         api_base_url = api_base_url.rstrip("/")
         # Auto-append /api/v1 if not present
@@ -28,6 +50,21 @@ class AGFSClient:
         self.api_base = api_base_url
         self.session = requests.Session()
         self.timeout = timeout
+        self.streaming_progress_timeout = streaming_progress_timeout
+
+    def _streaming_timeout(self):
+        """Tuple suitable for ``requests`` ``timeout=`` on streaming calls.
+
+        ``(connect_timeout, read_timeout)`` — the read leg is requests'
+        per-chunk inactivity timeout, which is exactly the per-chunk
+        progress bound this method enforces.
+
+        Returns ``None`` if ``streaming_progress_timeout`` was set to
+        ``None`` (opt-out path).
+        """
+        if self.streaming_progress_timeout is None:
+            return None
+        return (self.timeout, self.streaming_progress_timeout)
 
     def _handle_request_error(self, e: Exception, operation: str = "request") -> None:
         """Convert request exceptions to user-friendly error messages"""
@@ -153,12 +190,15 @@ class AGFSClient:
 
             if stream:
                 params["stream"] = "true"
-                # Streaming mode - return response object for iteration
+                # Streaming mode - return response object for iteration.
+                # Use a per-chunk progress timeout (the read leg of the
+                # tuple) so a stalled server can't wedge callers forever.
+                # Setting ``streaming_progress_timeout=None`` opts out.
                 response = self.session.get(
                     f"{self.api_base}/files",
                     params=params,
                     stream=True,
-                    timeout=None  # No timeout for streaming
+                    timeout=self._streaming_timeout(),
                 )
                 response.raise_for_status()
                 return response
@@ -190,14 +230,16 @@ class AGFSClient:
         Returns:
             Response message from server
         """
-        # Calculate timeout based on file size (if known)
-        # For streaming data, use a larger default timeout
+        # Calculate timeout based on file size (if known).
+        # For streaming data we used to set ``write_timeout = None`` which
+        # let a stalled server hang the client forever. Replace with the
+        # per-chunk streaming progress timeout — total upload time can
+        # still grow without bound, but inter-chunk silence is bounded.
         if isinstance(data, bytes):
             data_size_mb = len(data) / (1024 * 1024)
             write_timeout = max(10, min(300, int(data_size_mb * 1 + 10)))
         else:
-            # For streaming/unknown size, use no timeout
-            write_timeout = None
+            write_timeout = self._streaming_timeout()
 
         last_error = None
 
@@ -607,8 +649,8 @@ class AGFSClient:
             response = self.session.post(
                 f"{self.api_base}/grep",
                 json=request_body,
-                timeout=None if stream else self.timeout,
-                stream=stream
+                timeout=self._streaming_timeout() if stream else self.timeout,
+                stream=stream,
             )
             response.raise_for_status()
 

--- a/agfs-sdk/python/tests/test_streaming_progress_timeout.py
+++ b/agfs-sdk/python/tests/test_streaming_progress_timeout.py
@@ -1,0 +1,162 @@
+"""
+Focused tests for the SDK's streaming progress timeout.
+
+Before this change, ``AGFSClient.cat(stream=True)`` and friends passed
+``timeout=None`` to ``requests``, which meant a server that stopped
+sending bytes (or never sent any) could wedge the client forever. The
+new ``streaming_progress_timeout`` constructor argument enables a
+per-chunk inactivity timeout via the ``(connect_timeout, read_timeout)``
+tuple that ``requests`` supports natively.
+
+These tests stand up a tiny local HTTP server that deliberately stalls
+mid-stream and assert the client's ``iter_content`` loop raises
+``ReadTimeout`` rather than hanging.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+import requests
+
+from pyagfs import AGFSClient
+
+
+class _StallingHandler(BaseHTTPRequestHandler):
+    """Always responds 200 + chunked-encoding headers, then sleeps so
+    the body never arrives.
+
+    The handler advertises Transfer-Encoding: chunked and writes one
+    zero-byte placeholder so requests/urllib3 commits to reading the
+    body, then sleeps for ``STALL_SECONDS`` before sending any real
+    data. That is the exact "stalled stream" failure mode the progress
+    timeout is meant to bound.
+    """
+
+    STALL_SECONDS = 5
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        # Write nothing — let the client block on the first chunk read.
+        # Sleep longer than any reasonable test timeout so the test's
+        # progress-timeout assertion is the only way it can complete.
+        time.sleep(self.STALL_SECONDS)
+
+    def log_message(self, format, *args):  # noqa: A002 - matches stdlib
+        # Silence default access-log noise during the test.
+        return
+
+
+@pytest.fixture
+def stalling_server():
+    """Spin up the stalling server on a free port, hand back its base URL,
+    and tear it down on test exit."""
+
+    server = HTTPServer(("127.0.0.1", 0), _StallingHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+
+def test_streaming_read_progress_timeout_fires(stalling_server):
+    """A stalled server triggers a timeout when iterating the response,
+    rather than hanging until the test suite timeout kills the run.
+
+    The exact exception type depends on transport state: for a
+    chunked-encoding stream that's mid-body, urllib3's
+    ``ReadTimeoutError`` is wrapped by ``requests`` as
+    :class:`requests.exceptions.ConnectionError` carrying a "Read timed
+    out" message. For Content-Length responses it surfaces as
+    :class:`requests.exceptions.ReadTimeout`. We pin the user-visible
+    contract — a ``RequestException`` carrying the words ``timed out``
+    — rather than the exact subclass, so a future transport change
+    can't silently regress the bound.
+    """
+    client = AGFSClient(
+        api_base_url=stalling_server,
+        timeout=2,
+        streaming_progress_timeout=0.3,
+    )
+
+    response = client.cat("/anything", stream=True)
+    start = time.monotonic()
+    with pytest.raises(requests.exceptions.RequestException) as exc_info:
+        # Force a body read. The first chunk never arrives, so requests
+        # waits up to ``read_timeout`` for any bytes and then raises.
+        for _ in response.iter_content(chunk_size=1024):
+            pass
+    elapsed = time.monotonic() - start
+    assert "timed out" in str(exc_info.value).lower(), (
+        f"expected a timeout error message, got: {exc_info.value!r}"
+    )
+    # Sanity: we waited about the configured progress timeout, not the
+    # server's full stall window.
+    assert elapsed < _StallingHandler.STALL_SECONDS, (
+        f"streaming_progress_timeout did not fire — waited {elapsed:.2f}s"
+    )
+
+
+def test_streaming_timeout_opt_out_preserves_legacy_behaviour(stalling_server):
+    """Setting ``streaming_progress_timeout=None`` restores the
+    pre-2026-05 ``timeout=None`` behaviour for callers that need it.
+
+    We bound the test wait at sub-stall-window seconds and assert the
+    client is still inside the body-read loop (i.e. ``ReadTimeout`` did
+    NOT fire) — proving the opt-out is honoured.
+    """
+    client = AGFSClient(
+        api_base_url=stalling_server,
+        timeout=2,
+        streaming_progress_timeout=None,
+    )
+
+    response = client.cat("/anything", stream=True)
+
+    def consume():
+        try:
+            for _ in response.iter_content(chunk_size=1024):
+                pass
+        except requests.exceptions.RequestException:
+            pass
+
+    worker = threading.Thread(target=consume, daemon=True)
+    worker.start()
+    # Wait less than the server's stall so we don't actually receive
+    # data. If the opt-out is broken (a default progress timeout still
+    # applies), this thread joins early on ReadTimeout.
+    worker.join(timeout=0.8)
+    assert worker.is_alive(), (
+        "consume thread exited before stall completed — "
+        "streaming_progress_timeout=None did not opt out"
+    )
+
+
+def test_streaming_timeout_tuple_uses_connect_and_progress_legs():
+    """The internal helper builds a ``(connect, read)`` tuple from
+    ``timeout`` and ``streaming_progress_timeout``. Pin the shape so a
+    future refactor can't silently merge them back into a single value.
+    """
+    c = AGFSClient(
+        api_base_url="http://example.invalid",
+        timeout=11,
+        streaming_progress_timeout=22,
+    )
+    assert c._streaming_timeout() == (11, 22)
+
+    c_opt_out = AGFSClient(
+        api_base_url="http://example.invalid",
+        streaming_progress_timeout=None,
+    )
+    assert c_opt_out._streaming_timeout() is None


### PR DESCRIPTION
## Summary
- add configurable per-chunk streaming progress timeouts to Python and Go SDKs
- preserve unbounded total stream duration while bounding inter-byte silence
- add opt-out paths for callers that explicitly want legacy no-timeout behavior
- add Python and Go regression tests for stalled streams, opt-out behavior, and progress-keeping streams

## Verification
- Cross-review: PASS by @dev-1 in Slock task #13
- Python: `PYTHONPATH=. .venv/bin/python -m pytest tests/ --timeout=15` -> 3 passed
- Go: `go test ./... -timeout 30s` -> pass
- Go race: `go test -race -run TestStreamingProgressTimeout -timeout 30s` -> pass
- `git diff --check origin/master..HEAD` -> clean

## Notes
This bounds server-side streaming stalls. Locally blocked Python iterator uploads remain out of scope and would require a producer-side watchdog or async upload path.
