### PR TITLE
fix(agfs-shell): narrow high-risk broad exception catches

### DIFF
--- a/agfs-shell/agfs_shell/commands/llm.py
+++ b/agfs-shell/agfs_shell/commands/llm.py
@@ -2,6 +2,8 @@
 LLM command - (auto-migrated from builtins.py)
 """
 
+from pyagfs.exceptions import AGFSClientError
+
 from ..process import Process
 from ..command_decorators import command
 from . import register_command
@@ -117,17 +119,39 @@ def cmd_llm(process: Process) -> int:
             prompt_parts.append(arg)
             i += 1
 
-    # Load configuration from file if it exists
+    # Load configuration from file if it exists. The catches here are
+    # narrowed so that genuine programmer errors aren't masked as
+    # "config missing or unparseable" — every previously-silenced
+    # exception type is documented inline.
+    #
+    # ``_yaml`` and ``_config_parse_errors`` are resolved up front so
+    # the except-clause below can name the exact failure modes we
+    # intend to silence without depending on whether ``import yaml``
+    # succeeded in this scope.
+    _yaml = None
+    _config_parse_errors: tuple = (UnicodeDecodeError, ValueError)
+    try:
+        import yaml as _yaml_imported
+        _yaml = _yaml_imported
+        _config_parse_errors = _config_parse_errors + (_yaml.YAMLError,)
+    except ImportError:
+        pass
+
     config = {}
     try:
         if process.context.filesystem:
             config_content = process.context.filesystem.read_file(config_path)
             if config_content:
                 try:
-                    import yaml
-                    config = yaml.safe_load(config_content.decode('utf-8'))
-                    if not isinstance(config, dict):
-                        config = {}
+                    if _yaml is not None:
+                        config = _yaml.safe_load(config_content.decode('utf-8'))
+                        if not isinstance(config, dict):
+                            config = {}
+                    else:
+                        # PyYAML not available — fall back to simple
+                        # key=value parsing handled in the ImportError
+                        # branch below.
+                        raise ImportError("yaml unavailable")
                 except ImportError:
                     # If PyYAML not available, try simple key=value parsing
                     config_text = config_content.decode('utf-8')
@@ -137,10 +161,20 @@ def cmd_llm(process: Process) -> int:
                         if line and not line.startswith('#') and ':' in line:
                             key, value = line.split(':', 1)
                             config[key.strip()] = value.strip()
-                except Exception:
-                    pass  # Ignore config parse errors
-    except Exception:
-        pass  # Config file doesn't exist or can't be read
+                except _config_parse_errors:
+                    # Parse error in the config payload itself — keep
+                    # defaults rather than refuse to start, but only
+                    # silence the documented parse-failure modes.
+                    pass
+    except (AGFSClientError, OSError, UnicodeDecodeError):
+        # AGFSClientError: read_file failed at the filesystem boundary
+        # (server unreachable, permission denied, etc.).
+        # OSError: only relevant for local-file fallback paths.
+        # UnicodeDecodeError: payload isn't valid UTF-8.
+        # Anything else (AttributeError on a broken filesystem mock,
+        # TypeError on bogus arguments, ...) propagates so the bug is
+        # visible during development.
+        pass
 
     # Set defaults from config or hardcoded
     if not model_name:
@@ -227,10 +261,13 @@ def cmd_llm(process: Process) -> int:
         except Exception as e:
             return None, f"Failed to transcribe audio: {str(e)}"
         finally:
-            # Clean up temporary file
+            # Clean up temporary file. Only ``OSError`` is a legitimate
+            # silent failure mode here (file already gone, permission
+            # denied on a sandboxed tmpdir). Anything else (bug in the
+            # cleanup code itself, etc.) should surface.
             try:
                 os.unlink(tmp_path)
-            except Exception:
+            except OSError:
                 pass
 
     # Get input content: from --input-file or stdin

--- a/agfs-shell/agfs_shell/commands/ls.py
+++ b/agfs-shell/agfs_shell/commands/ls.py
@@ -3,6 +3,9 @@ LS command - list directory contents.
 """
 
 import os
+
+from pyagfs.exceptions import AGFSClientError
+
 from ..process import Process
 from ..command_decorators import command
 from ..utils.formatters import mode_to_rwx, human_readable_size
@@ -55,13 +58,18 @@ def cmd_ls(process: Process) -> int:
         meta = file_info.get('meta', {})
         is_symlink = meta.get('Type') == 'symlink'
 
-        # Get symlink target if this is a symlink
+        # Get symlink target if this is a symlink. ``readlink`` raises
+        # ``AGFSClientError`` for the documented "not a symlink /
+        # missing / unreadable" cases — those are the only failure
+        # modes where falling back to a plain-file display is correct.
+        # Any other exception type (programmer error, transport bug)
+        # bubbles up so the user actually hears about it.
         symlink_target = None
         if is_symlink and full_path:
             try:
                 symlink_target = process.context.filesystem.readlink(full_path)
-            except Exception:
-                # If readlink fails, just show as regular file
+            except AGFSClientError:
+                # readlink failed — fall back to plain-file display.
                 pass
 
         if long_format:

--- a/agfs-shell/agfs_shell/commands/tail.py
+++ b/agfs-shell/agfs_shell/commands/tail.py
@@ -3,6 +3,9 @@ TAIL command - output the last part of files.
 """
 
 import time
+
+from pyagfs.exceptions import AGFSClientError
+
 from ..process import Process
 from ..command_decorators import command
 from . import register_command
@@ -143,11 +146,17 @@ def cmd_tail(process: Process) -> int:
                         while True:
                             time.sleep(0.1)  # Poll every 100ms
 
-                            # Check file size
+                            # Check file size. Only "file disappeared
+                            # / unreadable" (AGFSClientError) is a
+                            # legitimate continue case here. Anything
+                            # else (programmer error, broken
+                            # filesystem object) must bubble — otherwise
+                            # `tail -f` becomes an infinite no-op on
+                            # the buggy condition.
                             try:
                                 file_info = process.context.filesystem.get_file_info(filename)
                                 new_size = file_info.get('size', 0)
-                            except Exception:
+                            except AGFSClientError:
                                 # File might not exist yet, keep waiting
                                 continue
 

--- a/agfs-shell/agfs_shell/commands/upload.py
+++ b/agfs-shell/agfs_shell/commands/upload.py
@@ -4,6 +4,8 @@ UPLOAD command - (auto-migrated from builtins.py)
 
 import os
 
+from pyagfs.exceptions import AGFSClientError
+
 from ..process import Process
 from ..command_decorators import command
 from . import register_command
@@ -43,7 +45,13 @@ def cmd_upload(process: Process) -> int:
             process.stderr.write(f"upload: {local_path}: No such file or directory\n")
             return 1
 
-        # Check if destination is a directory
+        # Check if destination is a directory. The "destination doesn't
+        # exist yet" case is signalled by ``AGFSClientError`` (the
+        # documented contract of ``filesystem.get_file_info``), so we
+        # only swallow that. Any other exception type — programmer
+        # error, attribute error, etc. — bubbles out to the outer
+        # handler instead of silently steering the upload to the wrong
+        # path.
         try:
             dest_info = process.context.filesystem.get_file_info(agfs_path)
             if dest_info.get('isDir', False):
@@ -51,8 +59,8 @@ def cmd_upload(process: Process) -> int:
                 source_basename = os.path.basename(local_path)
                 agfs_path = os.path.join(agfs_path, source_basename)
                 agfs_path = os.path.normpath(agfs_path)
-        except Exception:
-            # Destination doesn't exist, use as-is
+        except AGFSClientError:
+            # Destination doesn't exist (or is unreadable) — use as-is.
             pass
 
         if os.path.isfile(local_path):
@@ -69,6 +77,9 @@ def cmd_upload(process: Process) -> int:
             return 1
 
     except Exception as e:
+        # Outer boundary: surface any unexpected error to the user but
+        # don't let it crash the shell. Keep this catch broad — it is
+        # the documented command-level fallback.
         error_msg = str(e)
         process.stderr.write(f"upload: {error_msg}\n")
         return 1
@@ -95,18 +106,20 @@ def _upload_dir(process: Process, local_path: str, agfs_path: str) -> int:
     """Helper: Upload a directory recursively to AGFS"""
 
     try:
-        # Create target directory in AGFS if it doesn't exist
+        # Create target directory in AGFS if it doesn't exist. Only
+        # ``AGFSClientError`` is allowed to mean "missing" here — any
+        # other exception type is an unexpected bug and must bubble.
         try:
             info = process.context.filesystem.get_file_info(agfs_path)
             if not info.get('isDir', False):
                 process.stderr.write(f"upload: {agfs_path}: Not a directory\n")
                 return 1
-        except Exception:
-            # Directory doesn't exist, create it
+        except AGFSClientError:
+            # Directory doesn't exist, create it.
             try:
                 # Use mkdir command to create directory
                 process.context.filesystem.client.mkdir(agfs_path)
-            except Exception as e:
+            except AGFSClientError as e:
                 process.stderr.write(f"upload: cannot create directory {agfs_path}: {str(e)}\n")
                 return 1
 
@@ -120,14 +133,20 @@ def _upload_dir(process: Process, local_path: str, agfs_path: str) -> int:
                 current_agfs_dir = os.path.join(agfs_path, rel_path)
                 current_agfs_dir = os.path.normpath(current_agfs_dir)
 
-            # Create subdirectories in AGFS
+            # Create subdirectories in AGFS. We only ignore the
+            # specific "directory already exists" failure mode — which
+            # surfaces as an ``AGFSClientError``. Programmer errors
+            # (AttributeError, TypeError, ...) must not be silenced
+            # because they would let the upload proceed against a
+            # broken filesystem object.
             for dirname in dirs:
                 dir_agfs_path = os.path.join(current_agfs_dir, dirname)
                 dir_agfs_path = os.path.normpath(dir_agfs_path)
                 try:
                     process.context.filesystem.client.mkdir(dir_agfs_path)
-                except Exception:
-                    # Directory might already exist, ignore
+                except AGFSClientError:
+                    # mkdir on an existing directory raises here on the
+                    # server side; treat it as success for idempotency.
                     pass
 
             # Upload files
@@ -143,5 +162,7 @@ def _upload_dir(process: Process, local_path: str, agfs_path: str) -> int:
         return 0
 
     except Exception as e:
+        # Outer boundary — see comment in cmd_upload above. Keep broad
+        # so the shell never crashes on a single command's failure.
         process.stderr.write(f"upload: {str(e)}\n")
         return 1

--- a/agfs-shell/agfs_shell/completer.py
+++ b/agfs-shell/agfs_shell/completer.py
@@ -3,6 +3,9 @@
 import os
 import shlex
 from typing import List, Optional
+
+from pyagfs.exceptions import AGFSClientError
+
 from .builtins import BUILTINS
 from .filesystem import AGFSFileSystem
 
@@ -165,6 +168,11 @@ class ShellCompleter:
                     matches.append(final_path)
 
             return sorted(matches)
-        except Exception:
-            # If directory listing fails, return no matches
+        except AGFSClientError:
+            # Directory listing failed at the filesystem boundary —
+            # legitimately silence and return no completions, since
+            # tab-completion must never crash the REPL on transient
+            # network/permission errors. Programmer errors and other
+            # exception types are NOT silenced; they propagate to
+            # readline's handler so bugs surface in development.
             return []

--- a/agfs-shell/tests/test_narrow_broad_except.py
+++ b/agfs-shell/tests/test_narrow_broad_except.py
@@ -1,0 +1,170 @@
+"""
+Regression tests for narrowed broad-Exception catches in agfs-shell.
+
+Before task #15 these call sites swallowed every exception type as if
+it were the documented "external boundary" failure mode (path missing,
+network blip, etc.), silently steering the caller down the wrong path
+when a programmer error (AttributeError, TypeError, ...) actually
+fired. After the narrowing, only ``AGFSClientError`` — and a small
+explicit allow-list where the original intent was filesystem-level —
+is silenced. Anything else propagates to the command's outer boundary
+where the user sees a real error message and the command exits
+non-zero.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyagfs.exceptions import AGFSClientError
+
+from agfs_shell.commands.upload import cmd_upload
+from agfs_shell.commands.ls import cmd_ls
+
+
+def _make_process(args, filesystem, stdout=None, stderr=None, cwd="/"):
+    """Build a minimal Process-like object good enough for upload/ls."""
+    stdout = stdout or io.BytesIO()
+    stderr = stderr or io.BytesIO()
+
+    class _OutAdapter:
+        def __init__(self, buf):
+            self._buf = buf
+
+        def write(self, data):
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            self._buf.write(data)
+            return len(data)
+
+        def flush(self):
+            pass
+
+        @property
+        def value(self):
+            return self._buf.getvalue()
+
+    return SimpleNamespace(
+        args=list(args),
+        cwd=cwd,
+        stdout=_OutAdapter(stdout),
+        stderr=_OutAdapter(stderr),
+        context=SimpleNamespace(filesystem=filesystem, cwd=cwd),
+    )
+
+
+class TestUploadNarrowedExcept:
+    """``cmd_upload`` must only silence ``AGFSClientError`` from
+    ``get_file_info`` — other exception types are real bugs and must
+    surface so the user sees a real error instead of the upload
+    silently steering to the wrong path."""
+
+    def test_destination_missing_via_agfs_error_falls_through(self, tmp_path):
+        """The documented "destination doesn't exist" path is still
+        silently allowed (AGFSClientError ⇒ use the user-supplied
+        agfs_path verbatim)."""
+        local = tmp_path / "src.txt"
+        local.write_bytes(b"hello")
+
+        fs = MagicMock()
+        fs.get_file_info.side_effect = AGFSClientError("not found")
+        # write_file accepts the upload.
+        fs.write_file.return_value = None
+
+        proc = _make_process([str(local), "/dst.txt"], fs)
+        rc = cmd_upload(proc)
+
+        assert rc == 0
+        # write_file was called with the user-supplied path, NOT with
+        # a directory-appended variant.
+        fs.write_file.assert_called_once()
+        assert fs.write_file.call_args.args[0] == "/dst.txt"
+
+    def test_destination_lookup_unexpected_error_surfaces(self, tmp_path):
+        """A programmer-error exception type from ``get_file_info``
+        (e.g. ``AttributeError``) used to be silently swallowed.
+        Now it bubbles to the command boundary, which writes a real
+        error to stderr and returns non-zero. The upload must NOT
+        proceed against a broken filesystem object."""
+        local = tmp_path / "src.txt"
+        local.write_bytes(b"hello")
+
+        fs = MagicMock()
+        fs.get_file_info.side_effect = AttributeError("filesystem is broken")
+        fs.write_file.return_value = None
+
+        proc = _make_process([str(local), "/dst.txt"], fs)
+        rc = cmd_upload(proc)
+
+        assert rc != 0
+        assert b"filesystem is broken" in proc.stderr.value
+        fs.write_file.assert_not_called()
+
+
+class TestLsReadlinkNarrowedExcept:
+    """``cmd_ls`` falls back to a plain-file display when
+    ``readlink`` raises ``AGFSClientError`` (legitimate filesystem
+    error), but propagates anything else — covered by the outer
+    command boundary."""
+
+    def _make_fs_with_symlink(self, readlink_side_effect):
+        fs = MagicMock()
+        # Top-level path is a directory.
+        fs.get_file_info.return_value = {
+            "name": "/",
+            "isDir": True,
+            "type": "directory",
+            "size": 0,
+            "mode": 0o755,
+            "modTime": "",
+        }
+        # Single symlink child.
+        fs.list_directory.return_value = [
+            {
+                "name": "link",
+                "isDir": False,
+                "size": 0,
+                "mode": 0o777,
+                "modTime": "",
+                "meta": {"Type": "symlink"},
+            }
+        ]
+        fs.readlink.side_effect = readlink_side_effect
+        return fs
+
+    def test_readlink_agfs_error_falls_back_to_plain(self):
+        """``AGFSClientError`` from ``readlink`` is treated as
+        "not really a symlink we can resolve" — display continues
+        without the `→ target` arrow."""
+        fs = self._make_fs_with_symlink(AGFSClientError("not a symlink"))
+        proc = _make_process(["-l", "/"], fs)
+        rc = cmd_ls(proc)
+
+        assert rc == 0
+        out = proc.stdout.value.decode("utf-8", errors="replace")
+        assert "link" in out
+        # When readlink fails with AGFSClientError, the display falls
+        # back to a plain-file listing and the "->" target marker is
+        # not emitted.
+        assert "->" not in out
+
+    def test_readlink_unexpected_error_surfaces(self):
+        """A non-AGFS exception type from ``readlink`` (programmer
+        error, broken mock, ...) must NOT be silently turned into a
+        plain-file display — it propagates to the per-path inner
+        ``except Exception`` block, which writes an ls error and sets
+        the command's exit code non-zero."""
+        fs = self._make_fs_with_symlink(RuntimeError("inner readlink bug"))
+        proc = _make_process(["-l", "/"], fs)
+        rc = cmd_ls(proc)
+
+        assert rc != 0
+        assert b"inner readlink bug" in proc.stderr.value
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- narrow high-risk inner `except Exception` catches in `agfs-shell` user-facing commands to documented external-boundary failures
- preserve broad outer command-level fallbacks so one command does not crash the shell/REPL
- add regression coverage for upload destination lookup and `ls -l` symlink `readlink` fallback behavior

## Scope
Touched the first P0 top-N sites from task #15:
- `commands/upload.py`
- `commands/ls.py`
- `commands/tail.py`
- `commands/llm.py`
- `completer.py`
- `tests/test_narrow_broad_except.py`

The remaining broad catches under `agfs_shell/` are intentionally left for follow-up audits.

## Review
Cross-review PASS from @dev-1 in Slock task #15 thread. Non-blocking note accepted: upload/ls paths are directly pinned by tests; tail/llm/completer changes are covered by full-suite execution plus code inspection and should get focused tests when touched again.

## Verification
- `git diff --check HEAD~1..HEAD`
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_narrow_broad_except.py -v --timeout=15` -> 4 passed
- `PYTHONPATH=. .venv/bin/python -m pytest tests/ --timeout=15` -> 366 passed, 1 xfailed

Part of stability issue #21. Closes task #15.
