### PR TITLE
fix(server): bound HTTP request bodies

### DIFF
--- a/agfs-server/cmd/server/main.go
+++ b/agfs-server/cmd/server/main.go
@@ -70,6 +70,7 @@ const sampleConfig = `# AGFS Server Configuration File
 server:
   address: ":8080"          # Server listen address
   log_level: "info"         # Log level: debug, info, warn, error
+  max_request_body_bytes: 67108864  # Max write/JSON request body size (64 MiB)
 
 # Plugin configurations
 plugins:
@@ -380,7 +381,9 @@ func main() {
 	// Create handlers
 	handler := handlers.NewHandler(mfs, trafficMonitor)
 	handler.SetVersionInfo(Version, GitCommit, BuildTime)
+	handler.SetMaxRequestBodyBytes(cfg.Server.MaxRequestBodyBytes)
 	pluginHandler := handlers.NewPluginHandler(mfs)
+	pluginHandler.SetMaxRequestBodyBytes(cfg.Server.MaxRequestBodyBytes)
 
 	// Setup routes
 	mux := http.NewServeMux()

--- a/agfs-server/config.example.yaml
+++ b/agfs-server/config.example.yaml
@@ -3,6 +3,7 @@
 server:
   address: ":8080"
   log_level: info # Options: debug, info, warn, error
+  max_request_body_bytes: 67108864 # Max write/JSON request body size (64 MiB)
 
 plugins:
   serverinfofs:

--- a/agfs-server/docs/http-body-limits-and-streaming.md
+++ b/agfs-server/docs/http-body-limits-and-streaming.md
@@ -1,0 +1,40 @@
+# HTTP Body Limits and Large-Write Strategy
+
+AGFS server caps write and JSON request bodies with `server.max_request_body_bytes`.
+When the value is unset or non-positive, the server uses the default `67108864`
+bytes (64 MiB). Over-limit requests fail before handler-level buffering with
+HTTP `413 Request Entity Too Large`.
+
+## Covered in the First Pass
+
+- Raw file writes: `PUT /api/v1/files` and raw `POST /api/v1/write`.
+- JSON write alias: `POST /api/v1/write` with `application/json`.
+- Stateful handle writes: `PUT /api/v1/handles/{id}/write`.
+- JSON control endpoints in the core and plugin handlers: rename, chmod,
+  digest, symlink, grep, mount, unmount, plugin load, and plugin unload.
+
+The first pass intentionally keeps the existing filesystem `Write(path, []byte,
+...)` contract. This bounds server memory risk for request ingestion without
+changing plugin write semantics in the same patch.
+
+## Already Streaming
+
+- File reads can stream through `GET /api/v1/files?stream=true` when the mounted
+  filesystem implements `filesystem.Streamer`.
+- Handle streams use `GET /api/v1/handles/{id}/stream`.
+- Digest calculation uses `Open` and fixed-size read buffers instead of loading
+  full files into handler memory.
+
+## Follow-Up Architecture Work
+
+- Add a write-streaming API that uses `filesystem.OpenWrite` plus `io.Copy`
+  where backends support it. Keep the current `Write([]byte)` path as the
+  compatibility fallback.
+- Teach storage plugins with native streaming or multipart support, especially
+  S3FS, to avoid buffering whole objects before upload.
+- Audit plugins that transform full file contents, especially VectorFS indexing,
+  so large inputs are chunked or rejected with explicit limits.
+- Add size limits or streaming downloads for external plugin loading from HTTP
+  and AGFS paths.
+- Document client guidance for chunked uploads once the server exposes a stable
+  write-streaming endpoint.

--- a/agfs-server/pkg/config/config.go
+++ b/agfs-server/pkg/config/config.go
@@ -16,34 +16,35 @@ type Config struct {
 
 // ServerConfig contains server-level configuration
 type ServerConfig struct {
-	Address  string `yaml:"address"`
-	LogLevel string `yaml:"log_level"`
+	Address             string `yaml:"address"`
+	LogLevel            string `yaml:"log_level"`
+	MaxRequestBodyBytes int64  `yaml:"max_request_body_bytes"`
 }
 
 // ExternalPluginsConfig contains configuration for external plugins
 type ExternalPluginsConfig struct {
-	Enabled       bool              `yaml:"enabled"`
-	PluginDir     string            `yaml:"plugin_dir"`
-	AutoLoad      bool              `yaml:"auto_load"`
-	PluginPaths   []string          `yaml:"plugin_paths"`
-	WASIMountPath string            `yaml:"wasi_mount_path"` // Directory to mount for WASI filesystem access
-	WASM          WASMPluginConfig  `yaml:"wasm"`            // WASM plugin specific configuration
+	Enabled       bool             `yaml:"enabled"`
+	PluginDir     string           `yaml:"plugin_dir"`
+	AutoLoad      bool             `yaml:"auto_load"`
+	PluginPaths   []string         `yaml:"plugin_paths"`
+	WASIMountPath string           `yaml:"wasi_mount_path"` // Directory to mount for WASI filesystem access
+	WASM          WASMPluginConfig `yaml:"wasm"`            // WASM plugin specific configuration
 }
 
 // WASMPluginConfig contains configuration for WASM plugins
 type WASMPluginConfig struct {
-	InstancePoolSize     int `yaml:"instance_pool_size"`      // Maximum concurrent instances per plugin (default: 10)
-	InstanceMaxLifetime  int `yaml:"instance_max_lifetime"`   // Maximum instance lifetime in seconds (0 = unlimited)
-	InstanceMaxRequests  int `yaml:"instance_max_requests"`   // Maximum requests per instance (0 = unlimited)
-	HealthCheckInterval  int `yaml:"health_check_interval"`   // Health check interval in seconds (0 = disabled)
+	InstancePoolSize     int  `yaml:"instance_pool_size"`     // Maximum concurrent instances per plugin (default: 10)
+	InstanceMaxLifetime  int  `yaml:"instance_max_lifetime"`  // Maximum instance lifetime in seconds (0 = unlimited)
+	InstanceMaxRequests  int  `yaml:"instance_max_requests"`  // Maximum requests per instance (0 = unlimited)
+	HealthCheckInterval  int  `yaml:"health_check_interval"`  // Health check interval in seconds (0 = disabled)
 	EnablePoolStatistics bool `yaml:"enable_pool_statistics"` // Enable pool statistics collection
 }
 
 // PluginConfig can be either a single plugin or an array of plugin instances
 type PluginConfig struct {
 	// For single instance plugins
-	Enabled bool   `yaml:"enabled"`
-	Path    string `yaml:"path"`
+	Enabled bool                   `yaml:"enabled"`
+	Path    string                 `yaml:"path"`
 	Config  map[string]interface{} `yaml:"config"`
 
 	// For multi-instance plugins (array format)

--- a/agfs-server/pkg/handlers/body_limits.go
+++ b/agfs-server/pkg/handlers/body_limits.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DefaultMaxRequestBodyBytes caps request bodies accepted by write and JSON
+// endpoints. The limit is deliberately conservative until large writes have a
+// true streaming path through every backend.
+const DefaultMaxRequestBodyBytes int64 = 64 * 1024 * 1024
+
+func normalizeMaxRequestBodyBytes(maxBytes int64) int64 {
+	if maxBytes <= 0 {
+		return DefaultMaxRequestBodyBytes
+	}
+	return maxBytes
+}
+
+func requestBodyTooLargeMessage(maxBytes int64) string {
+	return fmt.Sprintf("request body exceeds maximum size of %d bytes", maxBytes)
+}
+
+func readLimitedRequestBody(w http.ResponseWriter, r *http.Request, maxBytes int64) ([]byte, error) {
+	return io.ReadAll(http.MaxBytesReader(w, r.Body, normalizeMaxRequestBodyBytes(maxBytes)))
+}
+
+func decodeLimitedJSON(w http.ResponseWriter, r *http.Request, maxBytes int64, dst interface{}) error {
+	data, err := readLimitedRequestBody(w, r, maxBytes)
+	if err != nil {
+		return err
+	}
+	return json.NewDecoder(bytes.NewReader(data)).Decode(dst)
+}
+
+func isRequestBodyTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
+
+func writeRequestBodyError(w http.ResponseWriter, err error, maxBytes int64, invalidMessage string) {
+	if isRequestBodyTooLarge(err) {
+		writeError(w, http.StatusRequestEntityTooLarge, requestBodyTooLargeMessage(normalizeMaxRequestBodyBytes(maxBytes)))
+		return
+	}
+	writeError(w, http.StatusBadRequest, invalidMessage)
+}
+
+// SetMaxRequestBodyBytes sets the maximum accepted request body size in bytes.
+// Values <= 0 reset the handler to DefaultMaxRequestBodyBytes.
+func (h *Handler) SetMaxRequestBodyBytes(maxBytes int64) {
+	h.maxRequestBodyBytes = normalizeMaxRequestBodyBytes(maxBytes)
+}
+
+// MaxRequestBodyBytes returns the effective request body size limit in bytes.
+func (h *Handler) MaxRequestBodyBytes() int64 {
+	return h.maxRequestBodyBytes
+}
+
+// SetMaxRequestBodyBytes sets the maximum accepted request body size in bytes.
+// Values <= 0 reset the plugin handler to DefaultMaxRequestBodyBytes.
+func (ph *PluginHandler) SetMaxRequestBodyBytes(maxBytes int64) {
+	ph.maxRequestBodyBytes = normalizeMaxRequestBodyBytes(maxBytes)
+}
+
+// MaxRequestBodyBytes returns the effective request body size limit in bytes.
+func (ph *PluginHandler) MaxRequestBodyBytes() int64 {
+	return ph.maxRequestBodyBytes
+}

--- a/agfs-server/pkg/handlers/body_limits_test.go
+++ b/agfs-server/pkg/handlers/body_limits_test.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/c4pt0r/agfs/agfs-server/pkg/mountablefs"
+	"github.com/c4pt0r/agfs/agfs-server/pkg/plugin/api"
+	"github.com/c4pt0r/agfs/agfs-server/pkg/plugins/memfs"
+)
+
+func newBodyLimitTestHandler(maxBytes int64) (*Handler, *memfs.MemoryFS) {
+	fs := memfs.NewMemoryFS()
+	h := NewHandler(fs, nil)
+	h.SetMaxRequestBodyBytes(maxBytes)
+	return h, fs
+}
+
+func decodeErrorResponse(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var resp ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	return resp
+}
+
+func TestWriteFileRejectsOverLimitRequestBody(t *testing.T) {
+	h, fs := newBodyLimitTestHandler(4)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/files?path=/big.txt", strings.NewReader("12345"))
+	rec := httptest.NewRecorder()
+	h.WriteFile(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 413, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decodeErrorResponse(t, rec).Error; !strings.Contains(got, "maximum size of 4 bytes") {
+		t.Fatalf("unexpected error response: %q", got)
+	}
+	if data, err := fs.Read("/big.txt", 0, -1); err == nil || len(data) != 0 {
+		t.Fatalf("expected over-limit write to leave file absent, data=%q err=%v", string(data), err)
+	}
+}
+
+func TestWriteFileAllowsNormalRequestBody(t *testing.T) {
+	h, fs := newBodyLimitTestHandler(16)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/files?path=/ok.txt", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	h.WriteFile(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data, err := fs.Read("/ok.txt", 0, -1)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("expected written data %q, got %q", "hello", string(data))
+	}
+}
+
+func TestWriteAliasRejectsOverLimitJSONBody(t *testing.T) {
+	h, _ := newBodyLimitTestHandler(12)
+	mux := http.NewServeMux()
+	h.SetupRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/write?path=/json.txt", strings.NewReader(`{"data":"too-large"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 413, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleWriteRejectsOverLimitRequestBody(t *testing.T) {
+	h, fs := newBodyLimitTestHandler(4)
+	handle, err := fs.OpenHandle("/handle.txt", filesystem.O_RDWR|filesystem.O_CREATE, 0644)
+	if err != nil {
+		t.Fatalf("open handle failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/handles/1/write", strings.NewReader("12345"))
+	rec := httptest.NewRecorder()
+	h.HandleWrite(rec, req, strconv.FormatInt(handle.ID(), 10))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 413, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data, err := fs.Read("/handle.txt", 0, -1)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected handle write to leave file empty, got %q", string(data))
+	}
+}
+
+func TestPluginHandlerRejectsOverLimitJSONBody(t *testing.T) {
+	mfs := mountablefs.NewMountableFS(api.PoolConfig{})
+	ph := NewPluginHandler(mfs)
+	ph.SetMaxRequestBodyBytes(8)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mount", strings.NewReader(`{"fstype":"memfs"}`))
+	rec := httptest.NewRecorder()
+	ph.Mount(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 413, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequestBodyLimitDefaultsAndOverrides(t *testing.T) {
+	h, _ := newBodyLimitTestHandler(0)
+	if got := h.MaxRequestBodyBytes(); got != DefaultMaxRequestBodyBytes {
+		t.Fatalf("expected default limit %d, got %d", DefaultMaxRequestBodyBytes, got)
+	}
+	h.SetMaxRequestBodyBytes(1024)
+	if got := h.MaxRequestBodyBytes(); got != 1024 {
+		t.Fatalf("expected override limit 1024, got %d", got)
+	}
+}

--- a/agfs-server/pkg/handlers/handle_handlers.go
+++ b/agfs-server/pkg/handlers/handle_handlers.go
@@ -81,7 +81,6 @@ func parseOpenFlags(flagStr string) (filesystem.OpenFlag, error) {
 	return filesystem.OpenFlag(num), nil
 }
 
-
 // getHandleFS checks if the filesystem supports HandleFS and returns it
 func (h *Handler) getHandleFS() (filesystem.HandleFS, error) {
 	handleFS, ok := h.fs.(filesystem.HandleFS)
@@ -298,9 +297,9 @@ func (h *Handler) HandleWrite(w http.ResponseWriter, r *http.Request, handleIDSt
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedRequestBody(w, r, h.maxRequestBodyBytes)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read request body")
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "failed to read request body")
 		return
 	}
 

--- a/agfs-server/pkg/handlers/handlers.go
+++ b/agfs-server/pkg/handlers/handlers.go
@@ -25,21 +25,23 @@ import (
 
 // Handler wraps the FileSystem and provides HTTP handlers
 type Handler struct {
-	fs             filesystem.FileSystem
-	version        string
-	gitCommit      string
-	buildTime      string
-	trafficMonitor *TrafficMonitor
+	fs                  filesystem.FileSystem
+	version             string
+	gitCommit           string
+	buildTime           string
+	trafficMonitor      *TrafficMonitor
+	maxRequestBodyBytes int64
 }
 
 // NewHandler creates a new Handler
 func NewHandler(fs filesystem.FileSystem, trafficMonitor *TrafficMonitor) *Handler {
 	return &Handler{
-		fs:             fs,
-		version:        "dev",
-		gitCommit:      "unknown",
-		buildTime:      "unknown",
-		trafficMonitor: trafficMonitor,
+		fs:                  fs,
+		version:             "dev",
+		gitCommit:           "unknown",
+		buildTime:           "unknown",
+		trafficMonitor:      trafficMonitor,
+		maxRequestBodyBytes: DefaultMaxRequestBodyBytes,
 	}
 }
 
@@ -262,9 +264,9 @@ func (h *Handler) WriteFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := io.ReadAll(r.Body)
+	data, err := readLimitedRequestBody(w, r, h.maxRequestBodyBytes)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read request body")
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "failed to read request body")
 		return
 	}
 
@@ -387,8 +389,8 @@ func (h *Handler) Rename(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req RenameRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -415,8 +417,8 @@ func (h *Handler) Chmod(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req ChmodRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -432,8 +434,8 @@ func (h *Handler) Chmod(w http.ResponseWriter, r *http.Request) {
 // Digest handles POST /digest
 func (h *Handler) Digest(w http.ResponseWriter, r *http.Request) {
 	var req DigestRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+	if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid request body: "+err.Error())
 		return
 	}
 
@@ -645,8 +647,8 @@ func (h *Handler) Symlink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req SymlinkRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -779,8 +781,8 @@ func (h *Handler) SetupRoutes(mux *http.ServeMux) {
 			var req struct {
 				Data string `json:"data"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeError(w, http.StatusBadRequest, "invalid JSON body")
+			if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+				writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid JSON body")
 				return
 			}
 			// Get path from query parameter
@@ -1037,9 +1039,9 @@ type GrepRequest struct {
 
 // GrepMatch represents a single match result
 type GrepMatch struct {
-	File     string                 `json:"file"`              // File path
-	Line     int                    `json:"line"`              // Line number (1-indexed)
-	Content  string                 `json:"content"`           // Matched line content
+	File     string                 `json:"file"`               // File path
+	Line     int                    `json:"line"`               // Line number (1-indexed)
+	Content  string                 `json:"content"`            // Matched line content
 	Metadata map[string]interface{} `json:"metadata,omitempty"` // Optional metadata (e.g., score, distance for vector search)
 }
 
@@ -1052,8 +1054,8 @@ type GrepResponse struct {
 // Grep searches for a pattern in files
 func (h *Handler) Grep(w http.ResponseWriter, r *http.Request) {
 	var req GrepRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+	if err := decodeLimitedJSON(w, r, h.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, h.maxRequestBodyBytes, "invalid request body: "+err.Error())
 		return
 	}
 

--- a/agfs-server/pkg/handlers/plugin_handlers.go
+++ b/agfs-server/pkg/handlers/plugin_handlers.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,12 +19,16 @@ import (
 
 // PluginHandler handles plugin management operations
 type PluginHandler struct {
-	mfs *mountablefs.MountableFS
+	mfs                 *mountablefs.MountableFS
+	maxRequestBodyBytes int64
 }
 
 // NewPluginHandler creates a new plugin handler
 func NewPluginHandler(mfs *mountablefs.MountableFS) *PluginHandler {
-	return &PluginHandler{mfs: mfs}
+	return &PluginHandler{
+		mfs:                 mfs,
+		maxRequestBodyBytes: DefaultMaxRequestBodyBytes,
+	}
 }
 
 // MountInfo represents information about a mounted plugin
@@ -64,8 +67,8 @@ type UnmountRequest struct {
 // Unmount handles POST /unmount
 func (ph *PluginHandler) Unmount(w http.ResponseWriter, r *http.Request) {
 	var req UnmountRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, ph.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, ph.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -92,8 +95,8 @@ type MountRequest struct {
 // Mount handles POST /mount
 func (ph *PluginHandler) Mount(w http.ResponseWriter, r *http.Request) {
 	var req MountRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, ph.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, ph.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -128,7 +131,6 @@ func (ph *PluginHandler) Mount(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, SuccessResponse{Message: "plugin mounted"})
 }
-
 
 // LoadPluginRequest represents a request to load an external plugin
 type LoadPluginRequest struct {
@@ -249,8 +251,8 @@ func (ph *PluginHandler) readPluginFromAGFS(agfsPath string) (string, error) {
 // LoadPlugin handles POST /plugins/load
 func (ph *PluginHandler) LoadPlugin(w http.ResponseWriter, r *http.Request) {
 	var req LoadPluginRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, ph.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, ph.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 
@@ -317,8 +319,8 @@ type UnloadPluginRequest struct {
 // UnloadPlugin handles POST /plugins/unload
 func (ph *PluginHandler) UnloadPlugin(w http.ResponseWriter, r *http.Request) {
 	var req UnloadPluginRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeLimitedJSON(w, r, ph.maxRequestBodyBytes, &req); err != nil {
+		writeRequestBodyError(w, err, ph.maxRequestBodyBytes, "invalid request body")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- add a 64 MiB default request-body cap for write and JSON endpoints
- wire `server.max_request_body_bytes` through config, handler setup, and sample config
- return `413 Request Entity Too Large` before handler-level buffering or filesystem writes
- document remaining large-write streaming architecture gaps

## Scope
Covered in this first pass:
- raw file writes and `/api/v1/write`
- handle writes
- core JSON control endpoints
- plugin JSON endpoints

This intentionally preserves the existing `Write(path, []byte, ...)` filesystem contract. True streaming writes, S3 multipart, VectorFS chunking, plugin-load download limits, and per-endpoint tighter JSON caps are tracked as follow-up architecture work.

## Review
Cross-review PASS from @dev-2 in Slock task #10 thread. Non-blocking follow-ups accepted: global limit vs per-endpoint caps, plugin-loader download limits, connection-close behavior from `http.MaxBytesReader`, and the bounded read-then-decode JSON helper shape.

## Verification
- `git diff --check HEAD~1..HEAD`
- `go test ./pkg/handlers -v -timeout 30s` -> PASS
- `go test ./... -timeout 300s` -> PASS

Part of stability issue #21. Closes task #10.
