### PR TITLE
feat(server): expose readiness and mount status

### DIFF
--- a/agfs-server/cmd/server/main.go
+++ b/agfs-server/cmd/server/main.go
@@ -229,6 +229,7 @@ func main() {
 
 	// Create traffic monitor early so it can be injected into plugins during mounting
 	trafficMonitor := handlers.NewTrafficMonitor()
+	mountStatusTracker := handlers.NewMountStatusTracker()
 
 	// Register plugin factories for dynamic mounting
 	for pluginName, factory := range availablePlugins {
@@ -239,8 +240,12 @@ func main() {
 		})
 	}
 
-	// mountPlugin initializes and mounts a plugin asynchronously
+	// mountPlugin initializes and mounts a configured plugin asynchronously.
+	// Readiness is tracked separately so failed mounts are visible even when
+	// they never enter the mount tree.
 	mountPlugin := func(pluginName, instanceName, mountPath string, pluginConfig map[string]interface{}) {
+		mountStatusTracker.Track(pluginName, instanceName, mountPath, pluginConfig)
+
 		// Get plugin factory (try built-in first, then external)
 		factory, ok := availablePlugins[pluginName]
 		var p plugin.ServicePlugin
@@ -249,7 +254,9 @@ func main() {
 			// Try to get external plugin from mfs
 			p = mfs.CreatePlugin(pluginName)
 			if p == nil {
-				log.Warnf("Unknown plugin: %s, skipping instance '%s'", pluginName, instanceName)
+				err := fmt.Errorf("unknown plugin: %s", pluginName)
+				mountStatusTracker.SetFailed(mountPath, err)
+				log.Warnf("%v, skipping instance '%s'", err, instanceName)
 				return
 			}
 		} else {
@@ -282,22 +289,26 @@ func main() {
 
 			// Validate plugin configuration
 			if err := p.Validate(configWithPath); err != nil {
+				mountStatusTracker.SetFailed(mountPath, err)
 				log.Errorf("Failed to validate %s instance '%s': %v", pluginName, instanceName, err)
 				return
 			}
 
 			// Initialize plugin
 			if err := p.Initialize(configWithPath); err != nil {
+				mountStatusTracker.SetFailed(mountPath, err)
 				log.Errorf("Failed to initialize %s instance '%s': %v", pluginName, instanceName, err)
 				return
 			}
 
 			// Mount plugin
 			if err := mfs.Mount(mountPath, p); err != nil {
+				mountStatusTracker.SetFailed(mountPath, err)
 				log.Errorf("Failed to mount %s instance '%s' at %s: %v", pluginName, instanceName, mountPath, err)
 				return
 			}
 
+			mountStatusTracker.SetMounted(mountPath)
 			// Log success
 			log.Infof("%s instance '%s' mounted at %s", pluginName, instanceName, mountPath)
 		}()
@@ -340,13 +351,18 @@ func main() {
 	devfsConfig := map[string]interface{}{
 		"mount_path": "/dev",
 	}
+	mountStatusTracker.Track("devfs", "devfs", "/dev", devfsConfig)
 	if err := devfsPlugin.Validate(devfsConfig); err != nil {
+		mountStatusTracker.SetFailed("/dev", err)
 		log.Errorf("Failed to validate DevFS: %v", err)
 	} else if err := devfsPlugin.Initialize(devfsConfig); err != nil {
+		mountStatusTracker.SetFailed("/dev", err)
 		log.Errorf("Failed to initialize DevFS: %v", err)
 	} else if err := mfs.Mount("/dev", devfsPlugin); err != nil {
+		mountStatusTracker.SetFailed("/dev", err)
 		log.Errorf("Failed to mount DevFS at /dev: %v", err)
 	} else {
+		mountStatusTracker.SetMounted("/dev")
 		log.Info("DevFS mounted successfully at /dev")
 	}
 
@@ -382,8 +398,10 @@ func main() {
 	handler := handlers.NewHandler(mfs, trafficMonitor)
 	handler.SetVersionInfo(Version, GitCommit, BuildTime)
 	handler.SetMaxRequestBodyBytes(cfg.Server.MaxRequestBodyBytes)
+	handler.SetMountStatusTracker(mountStatusTracker)
 	pluginHandler := handlers.NewPluginHandler(mfs)
 	pluginHandler.SetMaxRequestBodyBytes(cfg.Server.MaxRequestBodyBytes)
+	pluginHandler.SetMountStatusTracker(mountStatusTracker)
 
 	// Setup routes
 	mux := http.NewServeMux()

--- a/agfs-server/docs/readiness-and-mount-status.md
+++ b/agfs-server/docs/readiness-and-mount-status.md
@@ -1,0 +1,25 @@
+# Readiness and Mount Status
+
+AGFS starts its HTTP server before asynchronous configured mounts finish. The
+server now reports process health separately from mount readiness:
+
+- `GET /api/v1/health` always returns HTTP 200 when the process can answer. Its
+  JSON `status` is `healthy`, `starting`, or `degraded`.
+- `GET /api/v1/ready` returns HTTP 200 only after all tracked configured mounts
+  are mounted. It returns HTTP 503 while mounts are `pending` or when any mount
+  has `failed`.
+- `GET /api/v1/mounts` includes configured mounts that are still `pending` or
+  have `failed`, not just mounts that successfully entered the mount tree.
+
+Mount status fields:
+
+- `status`: `pending`, `mounted`, or `failed`
+- `error`: present for failed mounts
+- `mounts` summary on health/readiness: total, pending, mounted, failed
+
+The summary includes the always-on `/dev` mount as well as enabled configured
+plugins, so `total` is the complete startup mount set tracked by the server.
+
+This first pass does not make configured mounts block process startup. Operators
+and automation should use `/api/v1/ready` when they need the configured mount set
+to be usable before sending traffic.

--- a/agfs-server/pkg/handlers/handlers.go
+++ b/agfs-server/pkg/handlers/handlers.go
@@ -31,6 +31,7 @@ type Handler struct {
 	buildTime           string
 	trafficMonitor      *TrafficMonitor
 	maxRequestBodyBytes int64
+	mountStatusTracker  *MountStatusTracker
 }
 
 // NewHandler creates a new Handler
@@ -50,6 +51,12 @@ func (h *Handler) SetVersionInfo(version, gitCommit, buildTime string) {
 	h.version = version
 	h.gitCommit = gitCommit
 	h.buildTime = buildTime
+}
+
+// SetMountStatusTracker connects health/readiness responses to configured
+// mount lifecycle state.
+func (h *Handler) SetMountStatusTracker(tracker *MountStatusTracker) {
+	h.mountStatusTracker = tracker
 }
 
 // ErrorResponse represents an error response
@@ -562,21 +569,58 @@ func (h *Handler) Capabilities(w http.ResponseWriter, r *http.Request) {
 
 // HealthResponse represents the health check response
 type HealthResponse struct {
-	Status    string `json:"status"`
-	Version   string `json:"version"`
-	GitCommit string `json:"gitCommit"`
-	BuildTime string `json:"buildTime"`
+	Status    string       `json:"status"`
+	Version   string       `json:"version"`
+	GitCommit string       `json:"gitCommit"`
+	BuildTime string       `json:"buildTime"`
+	Ready     bool         `json:"ready"`
+	Degraded  bool         `json:"degraded"`
+	Mounts    MountSummary `json:"mounts"`
 }
 
 // Health handles GET /health
 func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.healthResponse())
+}
+
+// Ready handles GET /ready and returns 503 until configured mounts are fully ready.
+func (h *Handler) Ready(w http.ResponseWriter, r *http.Request) {
+	response := h.healthResponse()
+	status := http.StatusOK
+	if !response.Ready || response.Degraded {
+		status = http.StatusServiceUnavailable
+	}
+	writeJSON(w, status, response)
+}
+
+func (h *Handler) healthResponse() HealthResponse {
+	ready := true
+	degraded := false
+	mounts := MountSummary{}
+	if h.mountStatusTracker != nil {
+		ready = h.mountStatusTracker.Ready()
+		degraded = h.mountStatusTracker.Degraded()
+		mounts = h.mountStatusTracker.Summary()
+	}
+
+	status := "healthy"
+	if degraded {
+		status = "degraded"
+	} else if !ready {
+		status = "starting"
+	}
+
 	response := HealthResponse{
 		Status:    "healthy",
 		Version:   h.version,
 		GitCommit: h.gitCommit,
 		BuildTime: h.buildTime,
+		Ready:     ready,
+		Degraded:  degraded,
+		Mounts:    mounts,
 	}
-	writeJSON(w, http.StatusOK, response)
+	response.Status = status
+	return response
 }
 
 // Touch handles POST /touch?path=<path>
@@ -742,6 +786,13 @@ func (h *Handler) Truncate(w http.ResponseWriter, r *http.Request) {
 // SetupRoutes sets up all HTTP routes with /api/v1 prefix
 func (h *Handler) SetupRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/health", h.Health)
+	mux.HandleFunc("/api/v1/ready", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		h.Ready(w, r)
+	})
 	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/agfs-server/pkg/handlers/mount_status.go
+++ b/agfs-server/pkg/handlers/mount_status.go
@@ -1,0 +1,158 @@
+package handlers
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+)
+
+// Mount lifecycle states surfaced by health/readiness and mount-status APIs.
+const (
+	MountStatusPending = "pending"
+	MountStatusMounted = "mounted"
+	MountStatusFailed  = "failed"
+)
+
+// MountStatusInfo is the machine-readable lifecycle state for one configured mount.
+type MountStatusInfo struct {
+	Path       string                 `json:"path"`
+	PluginName string                 `json:"pluginName"`
+	Instance   string                 `json:"instance,omitempty"`
+	Status     string                 `json:"status"`
+	Error      string                 `json:"error,omitempty"`
+	Config     map[string]interface{} `json:"config,omitempty"`
+	UpdatedAt  string                 `json:"updatedAt"`
+}
+
+// MountSummary counts the current configured mount lifecycle states.
+type MountSummary struct {
+	Total   int `json:"total"`
+	Pending int `json:"pending"`
+	Mounted int `json:"mounted"`
+	Failed  int `json:"failed"`
+}
+
+// MountStatusTracker tracks configured mount lifecycle outside MountableFS, so
+// failed or still-pending configured mounts remain visible even when they never
+// enter the mount tree.
+type MountStatusTracker struct {
+	mu       sync.RWMutex
+	statuses map[string]MountStatusInfo
+}
+
+// NewMountStatusTracker creates an empty mount lifecycle tracker.
+func NewMountStatusTracker() *MountStatusTracker {
+	return &MountStatusTracker{statuses: make(map[string]MountStatusInfo)}
+}
+
+// Track records a configured mount as pending.
+func (t *MountStatusTracker) Track(pluginName, instanceName, path string, config map[string]interface{}) {
+	if t == nil {
+		return
+	}
+	path = filesystem.NormalizePath(path)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.statuses[path] = MountStatusInfo{
+		Path:       path,
+		PluginName: pluginName,
+		Instance:   instanceName,
+		Status:     MountStatusPending,
+		Config:     copyConfig(config),
+		UpdatedAt:  time.Now().Format(time.RFC3339Nano),
+	}
+}
+
+// SetMounted records a configured mount as mounted.
+func (t *MountStatusTracker) SetMounted(path string) {
+	if t == nil {
+		return
+	}
+	t.update(path, MountStatusMounted, "")
+}
+
+// SetFailed records a configured mount as failed with a user-visible error.
+func (t *MountStatusTracker) SetFailed(path string, err error) {
+	if t == nil {
+		return
+	}
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	t.update(path, MountStatusFailed, msg)
+}
+
+// Statuses returns configured mount statuses sorted by path.
+func (t *MountStatusTracker) Statuses() []MountStatusInfo {
+	if t == nil {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	statuses := make([]MountStatusInfo, 0, len(t.statuses))
+	for _, status := range t.statuses {
+		status.Config = copyConfig(status.Config)
+		statuses = append(statuses, status)
+	}
+	sort.Slice(statuses, func(i, j int) bool {
+		return statuses[i].Path < statuses[j].Path
+	})
+	return statuses
+}
+
+// Summary returns aggregate counts for configured mounts.
+func (t *MountStatusTracker) Summary() MountSummary {
+	statuses := t.Statuses()
+	summary := MountSummary{Total: len(statuses)}
+	for _, status := range statuses {
+		switch status.Status {
+		case MountStatusPending:
+			summary.Pending++
+		case MountStatusMounted:
+			summary.Mounted++
+		case MountStatusFailed:
+			summary.Failed++
+		}
+	}
+	return summary
+}
+
+// Ready reports whether all tracked configured mounts mounted successfully.
+func (t *MountStatusTracker) Ready() bool {
+	summary := t.Summary()
+	return summary.Pending == 0 && summary.Failed == 0
+}
+
+// Degraded reports whether any tracked configured mount failed.
+func (t *MountStatusTracker) Degraded() bool {
+	return t.Summary().Failed > 0
+}
+
+func (t *MountStatusTracker) update(path, status, errMsg string) {
+	path = filesystem.NormalizePath(path)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	current := t.statuses[path]
+	current.Path = path
+	current.Status = status
+	current.Error = errMsg
+	current.UpdatedAt = time.Now().Format(time.RFC3339Nano)
+	t.statuses[path] = current
+}
+
+func copyConfig(config map[string]interface{}) map[string]interface{} {
+	if len(config) == 0 {
+		return nil
+	}
+	copy := make(map[string]interface{}, len(config))
+	for k, v := range config {
+		copy[k] = v
+	}
+	return copy
+}

--- a/agfs-server/pkg/handlers/plugin_handlers.go
+++ b/agfs-server/pkg/handlers/plugin_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
@@ -21,6 +22,7 @@ import (
 type PluginHandler struct {
 	mfs                 *mountablefs.MountableFS
 	maxRequestBodyBytes int64
+	mountStatusTracker  *MountStatusTracker
 }
 
 // NewPluginHandler creates a new plugin handler
@@ -31,10 +33,19 @@ func NewPluginHandler(mfs *mountablefs.MountableFS) *PluginHandler {
 	}
 }
 
+// SetMountStatusTracker connects mount listing responses to configured mount
+// lifecycle state, including mounts that are pending or failed.
+func (ph *PluginHandler) SetMountStatusTracker(tracker *MountStatusTracker) {
+	ph.mountStatusTracker = tracker
+}
+
 // MountInfo represents information about a mounted plugin
 type MountInfo struct {
 	Path       string                 `json:"path"`
 	PluginName string                 `json:"pluginName"`
+	Instance   string                 `json:"instance,omitempty"`
+	Status     string                 `json:"status,omitempty"`
+	Error      string                 `json:"error,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
 }
 
@@ -48,13 +59,46 @@ func (ph *PluginHandler) ListMounts(w http.ResponseWriter, r *http.Request) {
 	mounts := ph.mfs.GetMounts()
 
 	var mountInfos []MountInfo
+	statusByPath := make(map[string]MountStatusInfo)
+	if ph.mountStatusTracker != nil {
+		for _, status := range ph.mountStatusTracker.Statuses() {
+			statusByPath[status.Path] = status
+			if status.Status != MountStatusMounted {
+				mountInfos = append(mountInfos, MountInfo{
+					Path:       status.Path,
+					PluginName: status.PluginName,
+					Instance:   status.Instance,
+					Status:     status.Status,
+					Error:      status.Error,
+					Config:     status.Config,
+				})
+			}
+		}
+	}
+
 	for _, mount := range mounts {
-		mountInfos = append(mountInfos, MountInfo{
+		status := MountStatusInfo{
 			Path:       mount.Path,
 			PluginName: mount.Plugin.Name(),
+			Status:     MountStatusMounted,
 			Config:     mount.Config,
+		}
+		if tracked, ok := statusByPath[mount.Path]; ok {
+			status = tracked
+			status.Status = MountStatusMounted
+		}
+		mountInfos = append(mountInfos, MountInfo{
+			Path:       status.Path,
+			PluginName: status.PluginName,
+			Instance:   status.Instance,
+			Status:     status.Status,
+			Error:      status.Error,
+			Config:     status.Config,
 		})
 	}
+	sort.Slice(mountInfos, func(i, j int) bool {
+		return mountInfos[i].Path < mountInfos[j].Path
+	})
 
 	writeJSON(w, http.StatusOK, ListMountsResponse{Mounts: mountInfos})
 }

--- a/agfs-server/pkg/handlers/readiness_test.go
+++ b/agfs-server/pkg/handlers/readiness_test.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/mountablefs"
+	"github.com/c4pt0r/agfs/agfs-server/pkg/plugin/api"
+	"github.com/c4pt0r/agfs/agfs-server/pkg/plugins/memfs"
+)
+
+func TestHealthAndReadyReflectMountLifecycle(t *testing.T) {
+	tracker := NewMountStatusTracker()
+	tracker.Track("localfs", "localfs", "/local", map[string]interface{}{"local_dir": "/missing"})
+
+	h := NewHandler(memfs.NewMemoryFS(), nil)
+	h.SetMountStatusTracker(tracker)
+
+	healthRec := httptest.NewRecorder()
+	h.Health(healthRec, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+	health := decodeHealthResponse(t, healthRec)
+	if healthRec.Code != http.StatusOK {
+		t.Fatalf("health should remain HTTP 200 while starting, got %d", healthRec.Code)
+	}
+	if health.Status != "starting" || health.Ready || health.Degraded {
+		t.Fatalf("unexpected starting health response: %+v", health)
+	}
+	if health.Mounts.Pending != 1 || health.Mounts.Failed != 0 {
+		t.Fatalf("unexpected starting mount summary: %+v", health.Mounts)
+	}
+
+	readyRec := httptest.NewRecorder()
+	h.Ready(readyRec, httptest.NewRequest(http.MethodGet, "/api/v1/ready", nil))
+	if readyRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("ready should be 503 while mounts are pending, got %d", readyRec.Code)
+	}
+
+	tracker.SetFailed("/local", errors.New("local_dir does not exist"))
+	healthRec = httptest.NewRecorder()
+	h.Health(healthRec, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+	health = decodeHealthResponse(t, healthRec)
+	if health.Status != "degraded" || health.Ready || !health.Degraded {
+		t.Fatalf("unexpected degraded health response: %+v", health)
+	}
+	if health.Mounts.Failed != 1 || health.Mounts.Pending != 0 {
+		t.Fatalf("unexpected degraded mount summary: %+v", health.Mounts)
+	}
+
+	tracker.SetMounted("/local")
+	readyRec = httptest.NewRecorder()
+	h.Ready(readyRec, httptest.NewRequest(http.MethodGet, "/api/v1/ready", nil))
+	ready := decodeHealthResponse(t, readyRec)
+	if readyRec.Code != http.StatusOK {
+		t.Fatalf("ready should be 200 once mounts succeed, got %d", readyRec.Code)
+	}
+	if ready.Status != "healthy" || !ready.Ready || ready.Degraded {
+		t.Fatalf("unexpected ready response: %+v", ready)
+	}
+}
+
+func TestListMountsIncludesPendingAndFailedConfiguredMounts(t *testing.T) {
+	tracker := NewMountStatusTracker()
+	tracker.Track("localfs", "localfs", "/local", map[string]interface{}{"local_dir": "/missing"})
+	tracker.SetFailed("/local", errors.New("local_dir does not exist"))
+	tracker.Track("queuefs", "jobs", "/queue", map[string]interface{}{"backend": "sqlite"})
+
+	ph := NewPluginHandler(mountablefs.NewMountableFS(api.PoolConfig{}))
+	ph.SetMountStatusTracker(tracker)
+
+	rec := httptest.NewRecorder()
+	ph.ListMounts(rec, httptest.NewRequest(http.MethodGet, "/api/v1/mounts", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response ListMountsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode mount response: %v", err)
+	}
+	if len(response.Mounts) != 2 {
+		t.Fatalf("expected 2 tracked mounts, got %d: %+v", len(response.Mounts), response.Mounts)
+	}
+	if response.Mounts[0].Path != "/local" || response.Mounts[0].Status != MountStatusFailed || response.Mounts[0].Error == "" {
+		t.Fatalf("failed mount status missing from response: %+v", response.Mounts[0])
+	}
+	if response.Mounts[1].Path != "/queue" || response.Mounts[1].Status != MountStatusPending {
+		t.Fatalf("pending mount status missing from response: %+v", response.Mounts[1])
+	}
+}
+
+func decodeHealthResponse(t *testing.T, rec *httptest.ResponseRecorder) HealthResponse {
+	t.Helper()
+	var response HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode health response: %v", err)
+	}
+	return response
+}


### PR DESCRIPTION
## Summary
- add mount lifecycle tracking for configured startup mounts (`pending`, `mounted`, `failed`)
- keep `/api/v1/health` as process liveness while surfacing `status`, `ready`, `degraded`, and mount summary counts
- add `/api/v1/ready`, returning 503 until tracked mounts are mounted and no failures remain
- include pending/failed configured mounts in `/api/v1/mounts`
- document readiness/mount-status semantics and note that the summary includes always-on `/dev`

## Review
Cross-review PASS from @dev-2 in Slock task #16 thread. Non-blocking follow-ups accepted: possible `/mounts` duplicate-row race during a status transition, and potential explicit JSON signal when no tracker is configured.

## Verification
- `git diff --check HEAD~1..HEAD`
- `go test ./pkg/handlers -v -timeout 30s` -> PASS
- `go test -race ./pkg/handlers -timeout 30s` -> PASS
- `go test ./... -timeout 300s` -> PASS

Part of stability issue #21. Closes task #16.
