### PR TITLE
docs: add first-run matrix and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ curl http://localhost:8080/api/v1/health
 
 Copy `config.example.yaml` to `config.yaml` only when you need local customization.
 
+For a complete first-run matrix across installer, source, Docker, shell, webapp, FUSE, and MCP paths, see [docs/first-run.md](./docs/first-run.md).
+
 Or via Docker:
 
 ```bash
@@ -248,4 +250,5 @@ See [task_loop.py](./agfs-mcp/demos/task_loop.py) for a complete example.
 - [agfs-server](./agfs-server/README.md) - Server configuration and plugin development
 - [agfs-shell](./agfs-shell/README.md) - Interactive shell client
 - [agfs-fuse](./agfs-fuse/README.md) - FUSE filesystem mount (Linux)
+- [First-run guide](./docs/first-run.md) - install/source/Docker/webapp/FUSE/MCP startup matrix and troubleshooting
 

--- a/agfs-fuse/README.md
+++ b/agfs-fuse/README.md
@@ -63,8 +63,21 @@ make install
 
 Press `Ctrl+C` in the terminal where agfs-fuse is running, or use:
 ```bash
+fusermount3 -u /mnt/agfs
+# or, on systems where fuse3 installs the legacy command name:
 fusermount -u /mnt/agfs
 ```
+
+## Troubleshooting
+
+- Verify the server first: `curl -sf http://localhost:8080/api/v1/health`.
+- `fusermount3: command not found`: install FUSE 3 packages, for example `sudo apt-get install fuse3 libfuse3-dev` on Debian/Ubuntu.
+- `failed to open /dev/fuse`: FUSE is not available to the process. On Docker/Linux, pass `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined`; Docker Desktop on macOS does not support this mount path.
+- `operation not permitted` with `--allow-other`: ensure `/etc/fuse.conf` contains `user_allow_other`, or mount without `--allow-other`.
+- Empty or stale listings: confirm the same server URL with `--agfs-server-url`, then lower `--cache-ttl` while debugging.
+- Unmount reports the target is busy: close processes using the mount, then run `lsof +f -- /mnt/agfs` to find remaining users.
+
+For the full AGFS first-run matrix, see [../docs/first-run.md](../docs/first-run.md).
 
 ## Usage
 

--- a/agfs-mcp/README.md
+++ b/agfs-mcp/README.md
@@ -244,6 +244,22 @@ Start a AGFS server first, then:
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | agfs-mcp
 ```
 
+## Troubleshooting
+
+- Verify AGFS before debugging MCP: `curl -sf http://localhost:8080/api/v1/health`.
+- MCP is a stdio JSON-RPC process for an MCP client. It does not open an HTTP port or browser UI.
+- If your MCP client cannot find `agfs-mcp`, use an absolute command path or a `uvx` config:
+  ```json
+  {
+    "command": "uvx",
+    "args": ["--from", "/path/to/agfs-mcp", "agfs-mcp"]
+  }
+  ```
+- If tools fail with connection errors, set `AGFS_SERVER_URL=http://host:8080` in the MCP client environment.
+- If `tools/list` works but AGFS operations fail, confirm plugin mounts with `curl -sf "http://localhost:8080/api/v1/directories?path=/"`.
+
+For the full AGFS first-run matrix, see [../docs/first-run.md](../docs/first-run.md).
+
 ## Architecture
 
 ```

--- a/agfs-shell/README.md
+++ b/agfs-shell/README.md
@@ -127,8 +127,10 @@ curl http://localhost:8080/api/v1/health
 
 # Option 2: Run from source
 cd agfs-server
-go run main.go
+make dev
 ```
+
+For the full installer/source/Docker/webapp/FUSE/MCP startup matrix, see [../docs/first-run.md](../docs/first-run.md).
 
 ## Installation
 

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -1,0 +1,67 @@
+# AGFS First-Run Guide
+
+This guide collects the supported first-run paths and the fastest checks for deciding whether the server, shell, webapp, FUSE mount, or MCP server is ready.
+
+## First-Run Matrix
+
+| Path | Use when | Prerequisites | Start command | Verify | Common next step |
+| --- | --- | --- | --- | --- | --- |
+| Installer with systemd | Linux host where AGFS should run as a service | `curl`, `sudo`, systemd | `curl -fsSL https://raw.githubusercontent.com/c4pt0r/agfs/master/install.sh \| sh` then `sudo systemctl start agfs-server` | `curl -sf http://localhost:8080/api/v1/health` | Inspect `sudo systemctl status agfs-server`; service config is `/etc/agfs.yaml`. |
+| Installer without systemd | Local user install or non-systemd host | `curl`, writable `~/.local/bin` | `curl -fsSL https://raw.githubusercontent.com/c4pt0r/agfs/master/install.sh \| sh` then `agfs-server -c ~/.config/agfs/config.yaml` | `curl -sf http://localhost:8080/api/v1/health` | Add `~/.local/bin` to `PATH` if `agfs-server` or `agfs` is not found. |
+| Source server | Development checkout | Go toolchain | `cd agfs-server && make dev` | `curl -sf http://localhost:8080/api/v1/health` | Copy `config.example.yaml` to `config.yaml` only for local edits; `make dev` falls back to the example config on a fresh checkout. |
+| Docker HTTP server | Quick server without local Go build | Docker | `docker run --rm -p 8080:8080 -e SKIP_FUSE_MOUNT=true c4pt0r/agfs:latest` | `curl -sf http://localhost:8080/api/v1/health` | Mount a host config with `-v "$(pwd)/config.yaml:/config.yaml"` when needed. |
+| agfs-shell | Interactive file operations against a running server | Python 3.10+, `uv`, reachable AGFS server | `cd agfs-shell && uv sync && uv run agfs-shell` | `uv run agfs-shell -c "ls /"` | Set `AGFS_API_URL=http://host:8080` or pass `--agfs-api-url` for non-local servers. |
+| Integrated webapp | Browser UI served by `agfs-shell` | Python 3.10+, `uv`, Node.js/npm, reachable AGFS server | `cd agfs-shell/webapp && npm ci && npm run build`; then `cd .. && uv sync --extra webapp && uv run agfs-shell --webapp` | Open `http://localhost:3000` | If startup reports missing `webapp/dist/index.html`, run the frontend build step again or `cd agfs-shell/webapp && ./setup.sh`. |
+| Webapp dev server | Frontend-only development with Vite proxy | Node.js/npm, AGFS server at `localhost:8080` | `cd agfs-shell/webapp && npm ci && npm run dev` | Open the Vite localhost URL | Keep Vite bound to localhost unless the dev server exposure has been reviewed. |
+| FUSE mount | Native filesystem mount on Linux | Linux, FUSE 3 packages, built `agfs-fuse`, reachable AGFS server | `cd agfs-fuse && make build && mkdir -p /tmp/agfs && ./build/agfs-fuse --agfs-server-url http://localhost:8080 --mount /tmp/agfs` | `ls /tmp/agfs` | Unmount with `fusermount3 -u /tmp/agfs` or `fusermount -u /tmp/agfs`. |
+| MCP server | Expose AGFS tools to an MCP client | Python 3.10+, `uv`, reachable AGFS server | `cd agfs-mcp && uv sync && AGFS_SERVER_URL=http://localhost:8080 uv run agfs-mcp` | In the MCP client, call `tools/list` or `agfs_health` | The MCP process speaks JSON-RPC over stdio; do not expect an HTTP port. |
+
+## Health Checks
+
+Use these checks before debugging a client:
+
+```bash
+curl -sf http://localhost:8080/api/v1/health
+curl -sf "http://localhost:8080/api/v1/directories?path=/"
+cd agfs-shell && AGFS_API_URL=http://localhost:8080 uv run agfs-shell -c "ls /"
+```
+
+If the server runs on another host or port, use the same base URL everywhere:
+
+```bash
+export AGFS_API_URL=http://127.0.0.1:8080
+export AGFS_SERVER_URL=http://127.0.0.1:8080
+```
+
+`AGFS_API_URL` is the preferred shell variable. `AGFS_SERVER_URL` is used by MCP and is also accepted by shell configuration for compatibility. Set them independently when shell and MCP should talk to different AGFS servers.
+
+## Configuration Paths
+
+- `agfs-server/config.example.yaml` is the repository example. Keep it read-only and unchanged.
+- `agfs-server/config.yaml` is the source-development customization file. Create it with `cp config.example.yaml config.yaml` only when you want local edits.
+- `~/.config/agfs/config.yaml` is the installer-created direct-run config for `agfs-server -c ~/.config/agfs/config.yaml`.
+- `/etc/agfs.yaml` is the installer-created systemd service config on Linux.
+
+## FUSE Troubleshooting
+
+- `fusermount: command not found`: install FUSE 3 packages. On Debian/Ubuntu: `sudo apt-get install fuse3 libfuse3-dev`.
+- `Mount failed: fusermount3: failed to open /dev/fuse`: load or expose FUSE on the host. In Docker, pass `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined`; this is not supported by Docker Desktop on macOS.
+- `Error: --mount is required`: pass a real mount directory, for example `mkdir -p /tmp/agfs && ./build/agfs-fuse --mount /tmp/agfs`.
+- `connection refused` or empty root listing: verify `curl -sf http://localhost:8080/api/v1/health` first and pass the same URL with `--agfs-server-url`.
+- `operation not permitted` with `--allow-other`: ensure `/etc/fuse.conf` contains `user_allow_other`, or mount without `--allow-other`.
+- Stale listings after writes: lower `--cache-ttl`, or remount while debugging.
+- Unmount hangs or says target is busy: close processes using the mount, then run `fusermount3 -u /tmp/agfs` or `fusermount -u /tmp/agfs`. Use `lsof +f -- /tmp/agfs` to find open users.
+
+## MCP Troubleshooting
+
+- MCP starts but tools fail with connection errors: start AGFS first and verify `curl -sf http://localhost:8080/api/v1/health`.
+- The MCP client cannot find `agfs-mcp`: use an absolute command path, or configure `uvx --from /path/to/agfs-mcp agfs-mcp` while developing from a checkout.
+- The client points at the wrong server: set `AGFS_SERVER_URL=http://host:8080` in the MCP client environment.
+- `tools/list` works but file tools fail: confirm the target path exists with `curl -sf "http://localhost:8080/api/v1/directories?path=/"` and check plugin mount availability.
+- Nothing appears in a browser: MCP is stdio JSON-RPC for MCP clients, not an HTTP web server.
+
+## Webapp Troubleshooting
+
+- Integrated webapp exits before serving: build `agfs-shell/webapp/dist` with `npm ci && npm run build`, or run `./setup.sh` from `agfs-shell/webapp`.
+- Browser loads but API calls fail: verify the AGFS server health endpoint and set `AGFS_API_URL=http://host:8080` before starting `uv run agfs-shell --webapp`.
+- Vite dev server API calls fail: by default the Vite proxy expects AGFS at `http://localhost:8080`; start the server there or update `agfs-shell/webapp/vite.config.js` for local development.


### PR DESCRIPTION
## Summary
- add `docs/first-run.md` covering installer, source, Docker, shell, webapp, FUSE, and MCP first-run paths
- link the guide from root README plus shell/FUSE/MCP READMEs
- update stale shell source-server command to `make dev`
- add focused FUSE, MCP, and webapp troubleshooting entries
- document shell vs MCP environment variables, including when `AGFS_API_URL` and `AGFS_SERVER_URL` may differ

## Review
Cross-review PASS from @dev-2 in Slock task #23 thread. Non-blocking line-ending issue handled by applying with `git apply`; small env-var clarity sentence folded into final branch.

## Verification
- `git diff --check`
- `make -n -C agfs-server dev`
- `make -n -C agfs-fuse build`
- `cd agfs-shell && uv run agfs-shell --help`
- `cd agfs-shell/webapp && npm ci`
- `rg -n "npm ci|docs/first-run.md|make dev|fusermount3|AGFS_SERVER_URL|AGFS_API_URL" docs/first-run.md README.md agfs-shell/README.md agfs-fuse/README.md agfs-mcp/README.md`
- `ls agfs-mcp/demos/task_loop.py`

Part of stability issue #21. Closes task #23.
