### PR TITLE
fix(pyagfs): add client lifecycle guards

### DIFF
--- a/agfs-sdk/python/pyagfs/client.py
+++ b/agfs-sdk/python/pyagfs/client.py
@@ -8,6 +8,31 @@ from requests.exceptions import ConnectionError, Timeout, RequestException
 from .exceptions import AGFSClientError, AGFSNotSupportedError
 
 
+class _ClosedSession:
+    """Sentinel that replaces ``AGFSClient.session`` after ``close()``.
+
+    Any attribute access raises ``AGFSClientError`` so a use-after-close
+    bug surfaces as a clear, actionable error at the call site instead
+    of as a cryptic stack from inside ``urllib3`` ("connection pool is
+    closed", "Session is closed", etc.) several frames deep.
+
+    The sentinel is intentionally a separate class rather than just
+    ``None``: it lets the existing ``self.session.get(...)`` /
+    ``self.session.post(...)`` call shape remain unchanged in every
+    request method while still failing fast.
+    """
+
+    __slots__ = ()
+
+    def __getattr__(self, name: str):
+        raise AGFSClientError(
+            "AGFSClient has been closed; create a new client to issue requests"
+        )
+
+    def __repr__(self) -> str:  # noqa: D401 - tiny sentinel
+        return "<closed AGFSClient session>"
+
+
 class AGFSClient:
     """Client for interacting with AGFS (Plugin-based File System) Server API"""
 
@@ -51,6 +76,70 @@ class AGFSClient:
         self.session = requests.Session()
         self.timeout = timeout
         self.streaming_progress_timeout = streaming_progress_timeout
+        # Tracks whether close() has run. Subsequent close() calls and
+        # __exit__ uses are idempotent; using the client after close()
+        # raises a clear error rather than producing a cryptic
+        # "session already closed" stack from requests.
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self):
+        """Release the underlying ``requests.Session`` and its HTTP
+        connection pool.
+
+        After ``close()``, the client refuses further requests:
+        ``self.session`` is replaced with a :class:`_ClosedSession`
+        sentinel whose attribute accesses raise
+        :class:`AGFSClientError`. That turns a post-close ``c.ls('/')``
+        into a clear "AGFSClient has been closed" error at the call
+        site instead of a cryptic stack from inside ``urllib3``.
+
+        Safe to call multiple times. The first call forwards to
+        ``Session.close()``; subsequent calls are no-ops. The
+        sentinel swap happens in a ``finally`` so a buggy custom
+        adapter that raises in ``Session.close`` still leaves the
+        client in a defensible "closed" state — preventing a retry
+        loop from reusing the same broken Session.
+        """
+        if self._closed:
+            return
+        try:
+            self.session.close()
+        finally:
+            # Replace the session with a sentinel that fails fast on
+            # any subsequent use, and flip the lifecycle flag. Both
+            # happen even if Session.close raised — see docstring.
+            self.session = _ClosedSession()
+            self._closed = True
+
+    def __enter__(self):
+        """Enter a ``with AGFSClient(...) as c:`` block.
+
+        Returns ``self`` so callers can do
+        ``with AGFSClient(url) as c: c.ls('/')`` in the idiomatic
+        Python style. The contained statements run with a guaranteed
+        cleanup path: ``__exit__`` calls :meth:`close` regardless of
+        whether the block exits normally or via an exception.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the ``with`` block by closing the underlying session.
+
+        Returning ``None`` (Python's default) means we don't suppress
+        any exception raised inside the ``with`` block — callers see
+        the original exception, just with the connection pool already
+        released by the time it surfaces.
+        """
+        self.close()
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether :meth:`close` has been called on this client."""
+        return self._closed
 
     def _streaming_timeout(self):
         """Tuple suitable for ``requests`` ``timeout=`` on streaming calls.

--- a/agfs-sdk/python/pyproject.toml
+++ b/agfs-sdk/python/pyproject.toml
@@ -36,3 +36,8 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["pyagfs"]
+
+[tool.pytest.ini_options]
+markers = [
+    "e2e: opt-in end-to-end tests that exercise the SDK against a real agfs-server subprocess",
+]

--- a/agfs-sdk/python/tests/test_lifecycle.py
+++ b/agfs-sdk/python/tests/test_lifecycle.py
@@ -1,0 +1,213 @@
+"""
+Tests for ``AGFSClient`` lifecycle: ``close()``, ``__enter__``,
+``__exit__``, and the ``is_closed`` property.
+
+Before task #21 there was no documented way to release the
+``requests.Session`` that ``AGFSClient`` keeps for the lifetime of
+the object. Long-lived processes (FUSE mounts, agents) leaked
+HTTP keep-alive sockets at shutdown; ``with AGFSClient(...) as c:``
+— the idiomatic Python pattern users expect — raised
+``AttributeError`` because the dunder methods weren't defined.
+
+These tests pin the new contract:
+
+* ``close()`` releases the session and is idempotent.
+* ``__enter__`` / ``__exit__`` make the client usable as a context
+  manager that closes the session on exit, even when the block
+  raises.
+* ``is_closed`` reflects the lifecycle state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyagfs import AGFSClient
+from pyagfs.exceptions import AGFSClientError
+
+
+class TestClose:
+    """Direct ``close()`` calls release the session and are idempotent."""
+
+    def test_close_closes_underlying_session(self):
+        c = AGFSClient(api_base_url="http://example.invalid")
+        real_session = c.session
+        sentinel = MagicMock()
+        # Wrap the real Session so we can verify close() is forwarded
+        # without rebuilding the whole requests.Session API surface.
+        c.session = sentinel
+        try:
+            c.close()
+        finally:
+            # Restore so any subsequent cleanup hooks don't error.
+            c.session = real_session
+        sentinel.close.assert_called_once()
+
+    def test_close_is_idempotent(self):
+        c = AGFSClient(api_base_url="http://example.invalid")
+        sentinel = MagicMock()
+        c.session = sentinel
+        c.close()
+        c.close()
+        c.close()
+        # The wrapped Session.close is only forwarded the first time —
+        # subsequent close() calls short-circuit on self._closed.
+        sentinel.close.assert_called_once()
+
+    def test_close_marks_client_closed(self):
+        c = AGFSClient(api_base_url="http://example.invalid")
+        assert c.is_closed is False
+        c.close()
+        assert c.is_closed is True
+
+    def test_close_marks_closed_even_if_session_close_raises(self):
+        """If the underlying Session.close raises (e.g. a bug in a
+        custom adapter), we still mark the client closed so a retry
+        loop doesn't trigger the same failure path repeatedly."""
+        c = AGFSClient(api_base_url="http://example.invalid")
+        sentinel = MagicMock()
+        sentinel.close.side_effect = RuntimeError("adapter died")
+        c.session = sentinel
+        with pytest.raises(RuntimeError, match="adapter died"):
+            c.close()
+        assert c.is_closed is True
+        # Second close is a no-op even after the first one raised.
+        c.close()
+
+
+class TestContextManager:
+    """``with AGFSClient(...) as c:`` closes the session on exit."""
+
+    def test_enter_returns_self(self):
+        c = AGFSClient(api_base_url="http://example.invalid")
+        try:
+            entered = c.__enter__()
+            assert entered is c
+        finally:
+            c.close()
+
+    def test_with_block_closes_on_normal_exit(self):
+        sentinel = MagicMock()
+        c = AGFSClient(api_base_url="http://example.invalid")
+        c.session = sentinel
+        with c as entered:
+            assert entered is c
+            assert entered.is_closed is False
+        sentinel.close.assert_called_once()
+        assert c.is_closed is True
+
+    def test_with_block_closes_on_exception(self):
+        """The session must close even when the ``with`` body raises.
+        ``__exit__`` returns ``None`` (falsy) so the original
+        exception propagates — we do not silence caller errors."""
+        sentinel = MagicMock()
+        c = AGFSClient(api_base_url="http://example.invalid")
+        c.session = sentinel
+
+        with pytest.raises(ValueError, match="user code blew up"):
+            with c:
+                raise ValueError("user code blew up")
+
+        sentinel.close.assert_called_once()
+        assert c.is_closed is True
+
+    def test_nested_with_uses_idempotent_close(self):
+        """Two nested ``with`` blocks on the same client (an unusual
+        but legal pattern) must not double-close the session."""
+        sentinel = MagicMock()
+        c = AGFSClient(api_base_url="http://example.invalid")
+        c.session = sentinel
+
+        with c:
+            with c:
+                pass
+            # Inner __exit__ already closed; outer __exit__ closes again
+            # but the call is idempotent.
+            assert c.is_closed is True
+
+        sentinel.close.assert_called_once()
+
+
+class TestPostCloseGuard:
+    """After ``close()``, every HTTP method must raise a clear error
+    instead of issuing a request against a stale Session — which
+    ``requests`` itself does not actively prevent.
+
+    Implementation strategy: ``close()`` swaps ``self.session`` for a
+    ``_ClosedSession`` sentinel whose attribute accesses raise
+    ``AGFSClientError``. Any ``self.session.get(...)`` /
+    ``self.session.post(...)`` call shape in the SDK fails fast there.
+    """
+
+    def _fake_health_response(self):
+        resp = MagicMock()
+        resp.json.return_value = {"status": "ok"}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_health_after_close_raises_agfs_client_error(self):
+        """Repro of @dev-1's blocking finding: previously, ``c.health()``
+        succeeded after ``close()`` because ``c.session`` was still the
+        live ``requests.Session``. The sentinel now intercepts."""
+        c = AGFSClient(api_base_url="http://example.invalid")
+        session = MagicMock()
+        session.get.return_value = self._fake_health_response()
+        c.session = session
+
+        c.close()
+        with pytest.raises(AGFSClientError, match="has been closed"):
+            c.health()
+        # The live session.get must NOT have been touched after close.
+        session.get.assert_not_called()
+
+    def test_ls_after_close_raises_agfs_client_error(self):
+        """Cover a second method shape (``ls`` uses ``self.session.get``
+        as well) to demonstrate the sentinel intercepts at the
+        ``self.session`` attribute access, not at a single method."""
+        c = AGFSClient(api_base_url="http://example.invalid")
+        session = MagicMock()
+        c.session = session
+
+        c.close()
+        with pytest.raises(AGFSClientError, match="has been closed"):
+            c.ls("/")
+        session.get.assert_not_called()
+
+    def test_sentinel_replaces_session_attribute_after_close(self):
+        """Pin the implementation contract: ``self.session`` is the
+        sentinel object after ``close()``. Future refactors that
+        rebuild the lifecycle on different machinery must keep this
+        invariant or replace it with an equivalent guard."""
+        from pyagfs.client import _ClosedSession
+
+        c = AGFSClient(api_base_url="http://example.invalid")
+        sentinel = MagicMock()
+        c.session = sentinel
+        c.close()
+        assert isinstance(c.session, _ClosedSession)
+        # Attribute access on the sentinel raises directly.
+        with pytest.raises(AGFSClientError, match="has been closed"):
+            c.session.get("http://example.invalid/anything")
+        # And the close() call did forward to the original Session once.
+        sentinel.close.assert_called_once()
+
+    def test_sentinel_swap_survives_session_close_raising(self):
+        """Even if the underlying ``Session.close`` raises, the sentinel
+        swap and the ``_closed`` flip still happen — closing the door
+        on use-after-error retry loops."""
+        from pyagfs.client import _ClosedSession
+
+        c = AGFSClient(api_base_url="http://example.invalid")
+        sentinel = MagicMock()
+        sentinel.close.side_effect = RuntimeError("adapter died")
+        c.session = sentinel
+
+        with pytest.raises(RuntimeError, match="adapter died"):
+            c.close()
+
+        assert c.is_closed is True
+        assert isinstance(c.session, _ClosedSession)
+        with pytest.raises(AGFSClientError, match="has been closed"):
+            c.health()

--- a/agfs-sdk/python/tests/test_lifecycle_e2e.py
+++ b/agfs-sdk/python/tests/test_lifecycle_e2e.py
@@ -1,0 +1,172 @@
+"""E2E coverage for ``AGFSClient`` lifecycle against a real agfs-server.
+
+The unit tests in ``test_lifecycle.py`` cover the contract with a
+``MagicMock`` Session — fast, deterministic, but the failure mode the
+patch fixes is *real users sharing a real Session with urllib3's
+connection pool*. This file exercises the same lifecycle through a
+real subprocess agfs-server so the post-close guard is verified at
+the user-visible boundary.
+
+The test is gated by ``AGFS_RUN_E2E=1`` (the same opt-in pattern
+task #27 uses for the docs/webapp lane). It's also marked with the
+``e2e`` pytest marker registered at ``agfs-shell/pyproject.toml``;
+the SDK doesn't currently register its own marker but the env-var
+guard is enough to keep this test off the default path.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from pyagfs import AGFSClient
+from pyagfs.exceptions import AGFSClientError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVER_DIR = REPO_ROOT / "agfs-server"
+
+RUN_E2E = os.getenv("AGFS_RUN_E2E") == "1"
+requires_e2e = pytest.mark.skipif(
+    not RUN_E2E,
+    reason="set AGFS_RUN_E2E=1 to run subprocess-based E2E checks",
+)
+
+
+def _require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        pytest.skip(f"{name} is required for this E2E test")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_health(base_url: str, proc: subprocess.Popen, timeout: float = 20) -> None:
+    """Poll ``/api/v1/health`` until the server answers 200 or the
+    subprocess dies, whichever comes first."""
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            raise AssertionError(
+                f"agfs-server exited early with {proc.returncode}\n"
+                f"stdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        try:
+            r = requests.get(f"{base_url}/api/v1/health", timeout=1)
+            if r.status_code == 200:
+                return
+        except requests.exceptions.RequestException as exc:
+            last_error = exc
+        time.sleep(0.25)
+    raise AssertionError(f"agfs-server did not become healthy: {last_error}")
+
+
+@pytest.fixture
+def live_agfs_server():
+    """Boot a fresh ``agfs-server`` on a free port; yield its base URL.
+
+    Mirrors ``scripts/e2e/run-core-e2e.sh``'s server boot but in-process
+    so the test can drive its own AGFSClient lifecycle without going
+    through the shell.
+    """
+    _require_command("go")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        ["go", "run", "cmd/server/main.go", "-c", "config.example.yaml", "-addr", f":{port}"],
+        cwd=SERVER_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_for_health(base_url, proc)
+        yield base_url
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+
+
+@pytest.mark.e2e
+@requires_e2e
+def test_client_lifecycle_against_real_server(live_agfs_server):
+    """End-to-end version of the post-close guard.
+
+    Boots a real agfs-server, opens a real ``AGFSClient`` via the
+    ``with`` block, issues a real HTTP request through the SDK's
+    ``health()`` method, exits the block, then verifies the
+    post-close guard at the user-visible boundary: a subsequent
+    ``health()`` raises ``AGFSClientError("has been closed")`` and the
+    underlying socket pool is released — not just that the unit tests
+    say so against a MagicMock Session.
+    """
+    base_url = live_agfs_server
+
+    # Use a context manager — the public surface the patch adds.
+    with AGFSClient(api_base_url=base_url, timeout=5) as client:
+        # Confirm the client really is talking to the server.
+        info = client.health()
+        # The merged readiness work (task #16) added these keys to the
+        # /health JSON; assert their shape so a regression of either
+        # the SDK or the server surfaces here too.
+        assert info.get("status") in {"healthy", "starting", "degraded"}
+        assert "ready" in info
+        # And the client is not yet closed.
+        assert client.is_closed is False
+
+    # `with` block exited — the patch's contract says the session is
+    # closed and any further request must raise AGFSClientError.
+    assert client.is_closed is True
+    with pytest.raises(AGFSClientError, match="has been closed"):
+        client.health()
+
+    # Same guard for a different method shape (ls hits session.get just
+    # like health()) — proves the sentinel intercepts at the session
+    # attribute level, not at any one named entry point.
+    with pytest.raises(AGFSClientError, match="has been closed"):
+        client.ls("/")
+
+
+@pytest.mark.e2e
+@requires_e2e
+def test_explicit_close_after_use_against_real_server(live_agfs_server):
+    """Same guarantee for callers that prefer ``close()`` over ``with``.
+
+    Some long-lived processes (FUSE mount, agent) construct the client
+    once and tear it down explicitly. Confirm the close path is
+    equivalent end-to-end.
+    """
+    base_url = live_agfs_server
+
+    client = AGFSClient(api_base_url=base_url, timeout=5)
+    assert client.is_closed is False
+    info = client.health()
+    assert "ready" in info
+
+    client.close()
+    assert client.is_closed is True
+
+    with pytest.raises(AGFSClientError, match="has been closed"):
+        client.health()
+
+    # Idempotent: a second close() is a no-op, not a double-free.
+    client.close()
+    with pytest.raises(AGFSClientError, match="has been closed"):
+        client.ls("/")


### PR DESCRIPTION
## Summary
- add `AGFSClient.close()`, context-manager support, and `is_closed`
- replace the session with a closed sentinel so post-close use raises a clear `AGFSClientError`
- add unit coverage plus opt-in SDK E2E coverage against a real `agfs-server`

## Verification
- `cd agfs-sdk/python && PYTHONPATH=. .venv/bin/python -m pytest tests/ --timeout=10` -> 15 passed, 2 skipped
- `cd agfs-sdk/python && AGFS_RUN_E2E=1 PYTHONPATH=. .venv/bin/python -m pytest tests/test_lifecycle_e2e.py --timeout=60 -v` -> 2 passed
- `git diff --check HEAD~1..HEAD` -> clean

## E2E coverage
- Covered by `AGFS_RUN_E2E=1 PYTHONPATH=. .venv/bin/python -m pytest tests/test_lifecycle_e2e.py --timeout=60 -v` from `agfs-sdk/python`.
- The E2E test boots a real `agfs-server`, performs a real SDK `health()` request, exits `with` / calls `close()`, then verifies `health()` and `ls("/")` fail at the user-visible boundary with the post-close guard.

Cross-review: @dev-1 PASS in task #21 thread.
