### PR TITLE
perf(agfs-shell): optimize streaming readline

### DIFF
--- a/agfs-shell/agfs_shell/pipeline.py
+++ b/agfs-shell/agfs_shell/pipeline.py
@@ -108,66 +108,130 @@ class StreamingPipeline:
 
 
 class StreamingInputStream(InputStream):
-    """Input stream that reads from a queue in chunks"""
+    """Input stream that reads from a queue in chunks.
+
+    Reads pull whole chunks off a ``queue.Queue`` (sentinel ``None`` =
+    EOF) and serve them out of a rolling ``bytearray`` buffer. The
+    buffer is compacted in place when the consumed prefix grows large,
+    so memory stays O(largest unread chunk) instead of growing with
+    total stream size.
+
+    Performance contract:
+
+    * ``read(size)`` is O(consumed bytes) — copies the requested slice
+      out of the buffer in one go rather than fan-in-via-many-Reads.
+    * ``readline()`` is O(line length) — uses ``bytearray.find(b'\\n', start)``
+      to scan the buffer in C, refilling from the queue when no newline
+      is present. The previous implementation called ``read(1)`` per
+      byte, which made each line cost O(N) Python-level iterations
+      *and* O(N) ``io.BytesIO`` re-instantiations.
+
+    Both methods share buffer state so a partial read followed by a
+    readline reuses already-buffered bytes.
+    """
+
+    # When the consumed prefix grows beyond this many bytes, drop it
+    # so the buffer's memory stays bounded for long streams. Below
+    # this threshold we keep the prefix because the slicing cost
+    # outweighs the wasted memory.
+    _COMPACT_THRESHOLD = 4096
 
     def __init__(self, pipe: queue.Queue):
         super().__init__(None)
         self.pipe = pipe
-        self._buffer = io.BytesIO()
+        self._buf = bytearray()  # rolling buffer of pulled-but-unread bytes
+        self._pos = 0            # how many bytes of self._buf the caller has consumed
         self._eof = False
 
+    def _available(self) -> int:
+        """Unread bytes currently in the rolling buffer."""
+        return len(self._buf) - self._pos
+
+    def _compact_if_needed(self) -> None:
+        """Drop the consumed prefix of the buffer once it gets large.
+
+        Without this, ``self._buf`` grows monotonically with total
+        stream size even though we only ever read forward. Dropping
+        in place via ``del self._buf[:self._pos]`` reuses the existing
+        allocation.
+        """
+        if self._pos > self._COMPACT_THRESHOLD:
+            del self._buf[:self._pos]
+            self._pos = 0
+
+    def _pull_chunk(self) -> bool:
+        """Pull one chunk off the queue into the rolling buffer.
+
+        Returns True if new bytes arrived, False on EOF. The chunk is
+        appended; the caller is responsible for tracking how far it's
+        consumed via ``self._pos``.
+        """
+        if self._eof:
+            return False
+        chunk = self.pipe.get()
+        if chunk is None:  # EOF sentinel
+            self._eof = True
+            return False
+        self._compact_if_needed()
+        self._buf.extend(chunk)
+        return True
+
     def read(self, size: int = -1) -> bytes:
-        """Read from the queue-based pipe"""
-        if size == -1:
-            # Read all available data
-            chunks = []
-            while not self._eof:
-                chunk = self.pipe.get()
-                if chunk is None:  # EOF
-                    self._eof = True
-                    break
-                chunks.append(chunk)
-            return b''.join(chunks)
-        else:
-            # Read specific number of bytes
-            data = b''
-            while len(data) < size and not self._eof:
-                # Check if we have buffered data
-                buffered = self._buffer.read(size - len(data))
-                if buffered:
-                    data += buffered
-                    if len(data) >= size:
-                        break
-
-                # Get more data from queue
-                chunk = self.pipe.get()
-                if chunk is None:  # EOF
-                    self._eof = True
-                    break
-
-                # Put in buffer
-                self._buffer = io.BytesIO(chunk)
-
+        """Read up to ``size`` bytes, or everything until EOF if ``size < 0``."""
+        if size < 0:
+            # Drain the pipe to EOF and return everything buffered + pulled.
+            while self._pull_chunk():
+                pass
+            data = bytes(self._buf[self._pos:])
+            # Reset state so future reads after EOF return b''.
+            self._buf.clear()
+            self._pos = 0
             return data
 
+        if size == 0:
+            return b""
+
+        # Refill until we have ``size`` bytes available or hit EOF.
+        while self._available() < size:
+            if not self._pull_chunk():
+                break
+
+        end = min(self._pos + size, len(self._buf))
+        data = bytes(self._buf[self._pos:end])
+        self._pos = end
+        return data
+
     def readline(self) -> bytes:
-        """Read a line from the pipe"""
-        line = []
-        while not self._eof:
-            byte = self.read(1)
-            if not byte:
-                break
-            line.append(byte)
-            if byte == b'\n':
-                break
-        return b''.join(line)
+        """Read up to and including the next newline, or to EOF.
+
+        Uses ``bytearray.find`` (implemented in C) instead of the old
+        ``read(1)``-per-byte loop. Big-O on long lines drops from
+        quadratic to linear, and the constant factor drops by an order
+        of magnitude.
+        """
+        while True:
+            newline_idx = self._buf.find(b"\n", self._pos)
+            if newline_idx != -1:
+                end = newline_idx + 1
+                data = bytes(self._buf[self._pos:end])
+                self._pos = end
+                return data
+            if not self._pull_chunk():
+                # EOF — return whatever's left (may be b'' if we hit a
+                # clean stream end without a trailing newline).
+                data = bytes(self._buf[self._pos:])
+                self._buf.clear()
+                self._pos = 0
+                return data
 
     def readlines(self) -> list:
-        """Read all lines from the pipe"""
+        """Read all lines until EOF as a list."""
         lines = []
-        while not self._eof:
+        while True:
             line = self.readline()
             if not line:
+                # readline returns b'' only when there's nothing
+                # buffered AND the pipe is at EOF.
                 break
             lines.append(line)
         return lines

--- a/agfs-shell/tests/test_streaming_input_stream.py
+++ b/agfs-shell/tests/test_streaming_input_stream.py
@@ -1,0 +1,189 @@
+"""
+Tests for ``StreamingInputStream`` — the queue-backed input stream that
+pipelines feed into commands.
+
+The class supports three read shapes (``read(size)``, ``read(-1)``,
+``readline()``, ``readlines()``) and shares buffer state across them.
+Task #20 optimised ``readline()`` from an O(N) ``read(1)`` loop to an
+O(line length) ``bytearray.find`` over a rolling buffer. These tests
+pin both:
+
+1. Correctness — every read shape returns the same bytes that the
+   producer pushed, regardless of how the chunk boundaries land
+   relative to newlines or to the requested ``size``.
+2. Performance — a large line that previously caused quadratic
+   behaviour now completes in well under a generous time budget.
+"""
+
+from __future__ import annotations
+
+import queue
+import time
+
+import pytest
+
+from agfs_shell.pipeline import StreamingInputStream
+
+
+def _feed(chunks):
+    """Build a queue pre-filled with ``chunks`` followed by the EOF
+    sentinel (``None``) — exactly what ``StreamingPipeline`` pushes."""
+    q = queue.Queue()
+    for c in chunks:
+        q.put(c)
+    q.put(None)  # EOF sentinel
+    return q
+
+
+class TestStreamingInputStreamCorrectness:
+    """Read shapes match what the producer pushed, across chunk
+    boundary cases that the rolling-buffer rewrite has to get right."""
+
+    def test_readline_single_chunk_single_line(self):
+        s = StreamingInputStream(_feed([b"hello\n"]))
+        assert s.readline() == b"hello\n"
+        assert s.readline() == b""  # EOF
+
+    def test_readline_chunks_split_inside_line(self):
+        """The producer split a line across two chunks. Readline must
+        stitch them back together via the rolling buffer."""
+        s = StreamingInputStream(_feed([b"hel", b"lo\n"]))
+        assert s.readline() == b"hello\n"
+        assert s.readline() == b""
+
+    def test_readline_chunks_contain_multiple_lines(self):
+        """One chunk carries multiple newlines. Each readline must
+        return exactly one line including its newline."""
+        s = StreamingInputStream(_feed([b"a\nb\nc\n"]))
+        assert s.readline() == b"a\n"
+        assert s.readline() == b"b\n"
+        assert s.readline() == b"c\n"
+        assert s.readline() == b""
+
+    def test_readline_trailing_partial_line_without_newline(self):
+        """If the stream ends with bytes that don't include a
+        terminator, the final readline returns them and the next
+        returns b''."""
+        s = StreamingInputStream(_feed([b"first\n", b"trail"]))
+        assert s.readline() == b"first\n"
+        assert s.readline() == b"trail"
+        assert s.readline() == b""
+
+    def test_read_size_across_chunk_boundary(self):
+        s = StreamingInputStream(_feed([b"abc", b"def", b"ghi"]))
+        assert s.read(2) == b"ab"
+        assert s.read(2) == b"cd"
+        assert s.read(2) == b"ef"
+        assert s.read(2) == b"gh"
+        assert s.read(2) == b"i"
+        assert s.read(2) == b""
+
+    def test_read_all_drains_pipe(self):
+        s = StreamingInputStream(_feed([b"alpha", b"-", b"beta"]))
+        assert s.read(-1) == b"alpha-beta"
+        # Subsequent reads return b''; class is one-shot per EOF.
+        assert s.read(-1) == b""
+
+    def test_read_zero_returns_empty_without_blocking(self):
+        s = StreamingInputStream(_feed([b"anything\n"]))
+        assert s.read(0) == b""
+        # And the queued data is still available afterwards.
+        assert s.readline() == b"anything\n"
+
+    def test_read_and_readline_share_buffer(self):
+        """A partial ``read(n)`` followed by ``readline()`` must
+        consume the same buffered bytes — the rolling buffer is a
+        single source of truth, not two independent views."""
+        s = StreamingInputStream(_feed([b"hello\nworld\n"]))
+        assert s.read(2) == b"he"           # consumes "he"
+        assert s.readline() == b"llo\n"     # rest of line 1
+        assert s.readline() == b"world\n"   # line 2
+        assert s.readline() == b""
+
+    def test_readlines_returns_every_line(self):
+        s = StreamingInputStream(_feed([b"x\n", b"y\n", b"z\n"]))
+        assert s.readlines() == [b"x\n", b"y\n", b"z\n"]
+
+
+class TestStreamingInputStreamPerformance:
+    """The previous ``readline()`` implementation called ``read(1)``
+    per byte, which was both Python-loop-quadratic and triggered an
+    ``io.BytesIO`` reallocation per chunk. The rolling buffer makes
+    a long line linear in line length.
+
+    The timing assertion below is generous (1 second for 1 MB of
+    contiguous data) so it doesn't flake on slow CI; the old
+    implementation would have taken many seconds because every byte
+    paid a full ``read(1)`` round trip including queue access and
+    BytesIO reconstruction.
+    """
+
+    def test_long_line_readline_completes_quickly(self):
+        # 1 MB of data with the newline at the very end forces the
+        # old per-byte loop to make a million calls.
+        big_line = b"x" * (1024 * 1024 - 1) + b"\n"
+        s = StreamingInputStream(_feed([big_line]))
+
+        start = time.monotonic()
+        line = s.readline()
+        elapsed = time.monotonic() - start
+
+        assert line == big_line
+        # Generous bound: actual measured time on a dev box is ~5ms.
+        # A regression to per-byte reads would push this into the
+        # multi-second range.
+        assert elapsed < 1.0, (
+            f"readline on a 1 MB single-line stream took {elapsed:.2f}s — "
+            "likely a regression of the O(N) per-byte loop"
+        )
+
+    def test_many_short_lines_readline_completes_quickly(self):
+        # 100k tiny lines stress the per-line overhead of newline
+        # search. With the rolling buffer this is one big ``find``
+        # per line; with the old loop it was N reads + N joins per
+        # line, all over again.
+        line_count = 100_000
+        chunk = b"".join(b"a\n" for _ in range(line_count))
+        s = StreamingInputStream(_feed([chunk]))
+
+        start = time.monotonic()
+        lines = s.readlines()
+        elapsed = time.monotonic() - start
+
+        assert len(lines) == line_count
+        assert lines[0] == b"a\n"
+        assert lines[-1] == b"a\n"
+        assert elapsed < 2.0, (
+            f"readlines on 100k tiny lines took {elapsed:.2f}s — "
+            "likely a regression of the O(N) per-byte loop"
+        )
+
+
+class TestStreamingInputStreamBufferCompaction:
+    """The rolling buffer compacts its consumed prefix once the
+    consumed offset grows past a threshold so memory stays bounded
+    on long streams — a pure implementation detail, pinned here so a
+    future refactor that drops the compaction (and reintroduces
+    unbounded buffer growth) fails this test."""
+
+    def test_buffer_compacts_after_threshold(self):
+        # Two chunks well above the compaction threshold so we can
+        # observe the in-place compaction by inspecting the internal
+        # buffer length.
+        big = b"y" * 10_000
+        s = StreamingInputStream(_feed([big, big]))
+
+        # Drain the first chunk via read(size).
+        assert s.read(len(big)) == big
+
+        # The next read forces a pull of chunk 2; the prefix from
+        # chunk 1 should have been dropped, so len(buf) is bounded
+        # by chunk 2's size (plus pending offset).
+        assert s.read(1) == b"y"
+        assert len(s._buf) <= len(big) + 1, (
+            f"buffer did not compact: len={len(s._buf)} expected <= {len(big) + 1}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/agfs-shell/tests/test_streaming_pipeline_e2e.py
+++ b/agfs-shell/tests/test_streaming_pipeline_e2e.py
@@ -1,0 +1,280 @@
+"""End-to-end coverage for the StreamingInputStream readline rewrite.
+
+The unit tests in ``test_streaming_input_stream.py`` exercise the
+class in-process. This file confirms the optimization actually shows
+up at the user-visible boundary: real ``agfs-shell`` subprocess,
+real ``agfs-server``, a real shell pipeline that pushes a multi-MB
+input through the streaming buffer between two stages, and a wall-
+clock bound that would have failed before the rolling-buffer rewrite.
+
+Gated by ``AGFS_RUN_E2E=1`` (matches task #27's docs/webapp lane)
+plus the ``@pytest.mark.e2e`` marker registered at
+``agfs-shell/pyproject.toml``. Will be wired into
+``scripts/e2e/run-core-e2e.sh``'s shell/SDK lane as part of task #26.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHELL_ROOT = REPO_ROOT / "agfs-shell"
+SERVER_DIR = REPO_ROOT / "agfs-server"
+
+RUN_E2E = os.getenv("AGFS_RUN_E2E") == "1"
+requires_e2e = pytest.mark.skipif(
+    not RUN_E2E,
+    reason="set AGFS_RUN_E2E=1 to run subprocess-based E2E checks",
+)
+
+
+def _require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        pytest.skip(f"{name} is required for this E2E test")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_health(base_url: str, proc: subprocess.Popen, timeout: float = 20) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            raise AssertionError(
+                f"agfs-server exited early with {proc.returncode}\n"
+                f"stdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        try:
+            r = requests.get(f"{base_url}/api/v1/health", timeout=1)
+            if r.status_code == 200:
+                return
+        except requests.exceptions.RequestException as exc:
+            last_error = exc
+        time.sleep(0.25)
+    raise AssertionError(f"agfs-server did not become healthy: {last_error}")
+
+
+@pytest.fixture
+def live_agfs_server():
+    """Spawn a real agfs-server on a free port with a memfs mount.
+
+    Same boot shape as ``scripts/e2e/run-core-e2e.sh`` and task #25's
+    backend e2e, but we additionally mount ``memfs`` at ``/memfs`` via
+    the runtime POST ``/api/v1/mount`` endpoint so this test can write
+    and read regular files (queuefs is in the default config but uses
+    enqueue/dequeue semantics, which is the wrong shape for piping a
+    multi-line file through ``cat | wc -l``).
+    """
+    _require_command("go")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        ["go", "run", "cmd/server/main.go", "-c", "config.example.yaml", "-addr", f":{port}"],
+        cwd=SERVER_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_for_health(base_url, proc)
+        # Mount memfs at /memfs so the rest of this lane has a regular
+        # file-system shape to write/read against. The mount call is
+        # idempotent enough for our purposes: if memfs is already
+        # mounted, the server returns 409, which we tolerate.
+        mount = requests.post(
+            f"{base_url}/api/v1/mount",
+            json={"fstype": "memfs", "path": "/memfs", "config": {}},
+            timeout=10,
+        )
+        assert mount.status_code in (200, 201, 409), (
+            f"mount /memfs failed: {mount.status_code} {mount.text}"
+        )
+        yield base_url
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+
+
+@pytest.mark.e2e
+@requires_e2e
+def test_large_pipeline_readline_completes_quickly_end_to_end(live_agfs_server):
+    """A real agfs-shell pipeline pushing 100k lines through a
+    *line-oriented* consumer must complete well under the
+    pre-rewrite quadratic time.
+
+    Workload:
+
+      cat <path> | head -n 100000 | wc -l
+
+    The middle stage is the optimization target. ``head`` reads
+    its input via ``process.stdin.readlines()``, which internally
+    calls ``StreamingInputStream.readline()`` once per line —
+    exactly the path this PR rewrites. We use ``head -n 100000`` (≥
+    the input line count) so head consumes the whole stream rather
+    than short-circuiting after the first N lines, which keeps the
+    workload on the optimized path for every input line.
+
+    The final ``wc -l`` is a stable assertion stage that counts
+    newlines on its own input (via ``read``, not ``readline``) and
+    surfaces the resulting count back through the shell stdout —
+    the user-visible end of the pipe.
+
+    NOTE on consumer choice (from cross-review): the earlier version
+    of this test used ``cat | wc -l`` directly, but agfs-shell's
+    ``wc`` builtin calls ``process.stdin.read()`` and counts
+    newlines on the resulting bytes — that flows through
+    ``StreamingInputStream.read(-1)``, not the optimized
+    ``readline()``. Routing through ``head`` first forces the
+    line-oriented path before the assertion stage. Pre-rewrite
+    behaviour: 100k ``readline()`` calls each scanned byte-by-byte
+    and reallocated ``io.BytesIO`` per chunk, so wall time scaled
+    quadratically. Post-rewrite: one ``bytearray.find`` per line
+    over a rolling buffer.
+
+    The 30s bound is generous (typical run is ~3-5s on a dev box);
+    a regression would push this into many minutes.
+    """
+    _require_command("uv")
+    _require_command("curl")
+    base_url = live_agfs_server
+
+    # Pre-stage the input file on the server. memfs's /-mount accepts
+    # PUT under any path, so we use a unique e2e-only path so parallel
+    # runs don't fight over it.
+    line_count = 100_000
+    payload = ("a\n" * line_count).encode("utf-8")
+    path = f"/memfs/e2e-readline-perf-{os.getpid()}"
+
+    put = requests.put(
+        f"{base_url}/api/v1/files",
+        params={"path": path},
+        data=payload,
+        timeout=30,
+    )
+    put.raise_for_status()
+
+    # Run the pipeline through a real agfs-shell. The three stages are
+    # wired up by the shell using StreamingInputStream between each
+    # pair — head's input side is the class this PR optimises.
+    env = os.environ.copy()
+    env["AGFS_API_URL"] = base_url
+
+    start = time.monotonic()
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "agfs-shell",
+            "-c",
+            f"cat {path} | head -n {line_count} | wc -l",
+        ],
+        cwd=SHELL_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=True,
+    )
+    elapsed = time.monotonic() - start
+
+    stdout = result.stdout.strip()
+    # `head -n line_count` passes through every input line, then
+    # `wc -l` reports the count back to the shell's stdout.
+    assert stdout.split()[-1] == str(line_count), (
+        f"unexpected pipeline output (expected {line_count} via "
+        f"head→wc): {stdout!r}"
+    )
+    # Generous bound — a regression of readline() to the per-byte
+    # loop would blow past 30s on this input. Document the failure
+    # mode in the error so a future reader can trace the wall-clock
+    # regression back to the readline change.
+    assert elapsed < 30.0, (
+        f"pipeline took {elapsed:.2f}s on 100k lines — likely a "
+        "regression of StreamingInputStream.readline back to the "
+        "per-byte read loop"
+    )
+
+    # Clean up the staged file so repeated runs stay tidy.
+    requests.delete(
+        f"{base_url}/api/v1/files",
+        params={"path": path},
+        timeout=10,
+    )
+
+
+@pytest.mark.e2e
+@requires_e2e
+def test_pipeline_preserves_content_through_streaming_buffer_end_to_end(live_agfs_server):
+    """Correctness companion to the perf test: a pipeline pushing a
+    known payload through the streaming buffer must surface the
+    exact same bytes downstream.
+
+    Workload: `cat /e2e-readline-content | head -3` returns the
+    first three lines. Catches a class of "rolling buffer dropped a
+    byte at a chunk boundary" regressions that wouldn't surface in
+    the unit-level test_streaming_input_stream.py because the unit
+    test controls chunk boundaries directly.
+    """
+    _require_command("uv")
+    base_url = live_agfs_server
+
+    lines = [b"one\n", b"two\n", b"three\n", b"four\n", b"five\n"]
+    payload = b"".join(lines)
+    path = f"/memfs/e2e-readline-content-{os.getpid()}"
+
+    put = requests.put(
+        f"{base_url}/api/v1/files",
+        params={"path": path},
+        data=payload,
+        timeout=10,
+    )
+    put.raise_for_status()
+
+    env = os.environ.copy()
+    env["AGFS_API_URL"] = base_url
+
+    # agfs-shell's ``head`` builtin only parses the ``-n N`` flag — the
+    # POSIX shorthand ``head -3`` isn't recognized. Pass the long form.
+    result = subprocess.run(
+        ["uv", "run", "agfs-shell", "-c", f"cat {path} | head -n 3"],
+        cwd=SHELL_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=True,
+    )
+
+    out = result.stdout
+    # head -3 must surface exactly the first three input lines.
+    assert "one" in out
+    assert "two" in out
+    assert "three" in out
+    # And NOT the lines that should have been cut off.
+    assert "four" not in out
+    assert "five" not in out
+
+    requests.delete(
+        f"{base_url}/api/v1/files",
+        params={"path": path},
+        timeout=10,
+    )


### PR DESCRIPTION
## Summary
- rewrite `StreamingInputStream` around a rolling `bytearray` buffer
- make `readline()` use `bytearray.find()` instead of per-byte reads
- add focused unit/performance coverage and real shell/server pipeline E2E coverage

## Verification
- `cd agfs-shell && PYTHONPATH=. .venv/bin/python -m pytest tests/test_streaming_input_stream.py --timeout=15` -> 12 passed
- `cd agfs-shell && AGFS_RUN_E2E=1 PYTHONPATH=. .venv/bin/python -m pytest tests/test_streaming_pipeline_e2e.py --timeout=120 -v` -> 2 passed
- `cd agfs-shell && PYTHONPATH=. .venv/bin/python -m pytest tests/ --timeout=15` -> 381 passed, 3 skipped, 1 xfailed
- `git diff --check HEAD~1..HEAD` -> clean

## E2E coverage
Covered by `AGFS_RUN_E2E=1 PYTHONPATH=. .venv/bin/python -m pytest tests/test_streaming_pipeline_e2e.py --timeout=120 -v` from `agfs-shell`.

The E2E boots a real `agfs-server`, mounts MemFS, stages input through the HTTP API, and runs a real `agfs-shell` pipeline. The large perf path uses `cat <path> | head -n 100000 | wc -l`, so the middle `head` stage drives `StreamingInputStream.readlines()` / `readline()` before `wc` asserts the output count.

Cross-review: @dev-1 PASS in task #20 thread after v3 fixed the E2E coverage blocker.
