### PR TITLE
fix(queuefs): make SQLite dequeue atomic

### DIFF
--- a/agfs-server/pkg/plugins/queuefs/backend.go
+++ b/agfs-server/pkg/plugins/queuefs/backend.go
@@ -420,6 +420,22 @@ func (b *TiDBBackend) Dequeue(queueName string) (QueueMessage, bool, error) {
 		return QueueMessage{}, false, fmt.Errorf("failed to get queue table name: %w", err)
 	}
 
+	if querySQL, ok := b.backend.GetAtomicDequeueQuery(tableName); ok {
+		var data string
+		err = b.db.QueryRow(querySQL).Scan(&data)
+		if err == sql.ErrNoRows {
+			return QueueMessage{}, false, nil
+		} else if err != nil {
+			return QueueMessage{}, false, fmt.Errorf("failed to atomically dequeue message: %w", err)
+		}
+
+		var msg QueueMessage
+		if err := json.Unmarshal([]byte(data), &msg); err != nil {
+			return QueueMessage{}, false, fmt.Errorf("failed to unmarshal message: %w", err)
+		}
+		return msg, true, nil
+	}
+
 	// Start transaction
 	tx, err := b.db.Begin()
 	if err != nil {

--- a/agfs-server/pkg/plugins/queuefs/db_backend.go
+++ b/agfs-server/pkg/plugins/queuefs/db_backend.go
@@ -31,6 +31,11 @@ type DBBackend interface {
 	// GetDequeueQuery returns the SQL used to claim the next queue message.
 	GetDequeueQuery(tableName string) string
 
+	// GetAtomicDequeueQuery returns SQL that atomically marks the next message
+	// deleted and returns its data. Backends that cannot express this in one
+	// statement return ok=false and use GetDequeueQuery inside a transaction.
+	GetAtomicDequeueQuery(tableName string) (query string, ok bool)
+
 	// GetDriverName returns the driver name
 	GetDriverName() string
 }
@@ -49,7 +54,7 @@ func (b *SQLiteDBBackend) GetDriverName() string {
 func (b *SQLiteDBBackend) Open(cfg map[string]interface{}) (*sql.DB, error) {
 	dbPath := config.GetStringConfig(cfg, "db_path", "queue.db")
 
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite3", sqliteDSNWithDefaultBusyTimeout(dbPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}
@@ -59,8 +64,19 @@ func (b *SQLiteDBBackend) Open(cfg map[string]interface{}) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
 	}
-
 	return db, nil
+}
+
+func sqliteDSNWithDefaultBusyTimeout(dsn string) string {
+	if strings.Contains(dsn, "_busy_timeout=") || strings.Contains(dsn, "busy_timeout=") {
+		return dsn
+	}
+
+	separator := "?"
+	if strings.Contains(dsn, "?") {
+		separator = "&"
+	}
+	return dsn + separator + "_busy_timeout=5000"
 }
 
 func (b *SQLiteDBBackend) GetInitSQL() []string {
@@ -95,6 +111,18 @@ func (b *SQLiteDBBackend) GetRegisterQueueSQL() string {
 
 func (b *SQLiteDBBackend) GetDequeueQuery(tableName string) string {
 	return fmt.Sprintf("SELECT id, data FROM %s WHERE deleted = 0 ORDER BY id LIMIT 1", tableName)
+}
+
+func (b *SQLiteDBBackend) GetAtomicDequeueQuery(tableName string) (string, bool) {
+	return fmt.Sprintf(`UPDATE %s
+		SET deleted = 1, deleted_at = CURRENT_TIMESTAMP
+		WHERE id = (
+			SELECT id FROM %s
+			WHERE deleted = 0
+			ORDER BY id
+			LIMIT 1
+		)
+		RETURNING data`, tableName, tableName), true
 }
 
 // TiDBDBBackend implements DBBackend for TiDB
@@ -252,6 +280,10 @@ func (b *TiDBDBBackend) GetRegisterQueueSQL() string {
 
 func (b *TiDBDBBackend) GetDequeueQuery(tableName string) string {
 	return fmt.Sprintf("SELECT id, data FROM %s WHERE deleted = 0 ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED", tableName)
+}
+
+func (b *TiDBDBBackend) GetAtomicDequeueQuery(tableName string) (string, bool) {
+	return "", false
 }
 
 // Helper functions

--- a/agfs-server/pkg/plugins/queuefs/sqlite_backend_test.go
+++ b/agfs-server/pkg/plugins/queuefs/sqlite_backend_test.go
@@ -2,10 +2,13 @@ package queuefs
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
 )
@@ -27,6 +30,29 @@ func newSQLiteQueueFSTest(t *testing.T) filesystem.FileSystem {
 	})
 
 	return plugin.GetFileSystem()
+}
+
+func newSQLiteQueueBackendTest(t *testing.T) *TiDBBackend {
+	t.Helper()
+
+	plugin := NewQueueFSPlugin()
+	if err := plugin.Initialize(map[string]interface{}{
+		"backend": "sqlite",
+		"db_path": filepath.Join(t.TempDir(), "queuefs.db"),
+	}); err != nil {
+		t.Fatalf("initialize sqlite queuefs: %v", err)
+	}
+	t.Cleanup(func() {
+		if plugin.backend != nil {
+			_ = plugin.backend.Close()
+		}
+	})
+
+	backend, ok := plugin.backend.(*TiDBBackend)
+	if !ok {
+		t.Fatalf("unexpected backend type %T", plugin.backend)
+	}
+	return backend
 }
 
 func readQueueMessage(t *testing.T, fs filesystem.FileSystem, path string) QueueMessage {
@@ -186,5 +212,86 @@ func TestQueueFSSQLiteRequiresQueueCreation(t *testing.T) {
 
 	if _, err := fs.Write("/missing/enqueue", []byte("no queue"), -1, filesystem.WriteFlagCreate); err == nil {
 		t.Fatal("write to missing sqlite queue succeeded")
+	}
+}
+
+func TestQueueFSSQLiteConcurrentDequeueNoDuplicateDelivery(t *testing.T) {
+	backend := newSQLiteQueueBackendTest(t)
+	const queueName = "jobs"
+	const total = 64
+
+	if err := backend.CreateQueue(queueName); err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	want := make(map[string]struct{}, total)
+	for i := 0; i < total; i++ {
+		data := fmt.Sprintf("job-%02d", i)
+		want[data] = struct{}{}
+		if err := backend.Enqueue(queueName, QueueMessage{
+			ID:        fmt.Sprintf("msg-%02d", i),
+			Data:      data,
+			Timestamp: time.Unix(int64(i+1), 0),
+		}); err != nil {
+			t.Fatalf("enqueue %s: %v", data, err)
+		}
+	}
+
+	start := make(chan struct{})
+	results := make(chan QueueMessage, total)
+	errs := make(chan error, total)
+
+	var wg sync.WaitGroup
+	wg.Add(total)
+	for i := 0; i < total; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			msg, found, err := backend.Dequeue(queueName)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !found {
+				errs <- fmt.Errorf("concurrent dequeue returned empty queue before all messages were delivered")
+				return
+			}
+			results <- msg
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent dequeue error: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	got := make(map[string]int, total)
+	for msg := range results {
+		got[msg.Data]++
+	}
+	if len(got) != total {
+		t.Fatalf("unique dequeued messages = %d, want %d; got=%v", len(got), total, got)
+	}
+	for data := range want {
+		if got[data] != 1 {
+			t.Fatalf("message %q delivered %d times, want once; got=%v", data, got[data], got)
+		}
+	}
+
+	if size, err := backend.Size(queueName); err != nil {
+		t.Fatalf("size after concurrent dequeue: %v", err)
+	} else if size != 0 {
+		t.Fatalf("size after concurrent dequeue = %d, want 0", size)
+	}
+	if msg, found, err := backend.Dequeue(queueName); err != nil {
+		t.Fatalf("final empty dequeue: %v", err)
+	} else if found {
+		t.Fatalf("final empty dequeue returned %+v", msg)
 	}
 }

--- a/scripts/e2e/run-backend-e2e.sh
+++ b/scripts/e2e/run-backend-e2e.sh
@@ -189,7 +189,7 @@ http_code() {
 }
 
 write_healthy_config() {
-  cat >"$TMP_DIR/healthy.yaml" <<'YAML'
+  cat >"$TMP_DIR/healthy.yaml" <<YAML
 server:
   address: ":18082"
   log_level: warn
@@ -201,9 +201,16 @@ plugins:
     path: /memfs
     config: {}
   queuefs:
-    enabled: true
-    path: /queuefs
-    config: {}
+    - name: memory
+      enabled: true
+      path: /queuefs
+      config: {}
+    - name: sqlite
+      enabled: true
+      path: /queuefs-sqlite
+      config:
+        backend: sqlite
+        db_path: $TMP_DIR/queuefs-sqlite-e2e.db
   serverinfofs:
     enabled: true
     path: /serverinfo
@@ -250,6 +257,7 @@ healthy_server_e2e() {
   assert_mount_status "$mounts" "/dev" "mounted"
   assert_mount_status "$mounts" "/memfs" "mounted"
   assert_mount_status "$mounts" "/queuefs" "mounted"
+  assert_mount_status "$mounts" "/queuefs-sqlite" "mounted"
   assert_mount_status "$mounts" "/serverinfo" "mounted"
   assert_mount_status "$mounts" "/hello" "mounted"
 
@@ -283,6 +291,39 @@ healthy_server_e2e() {
   curl -fsS -X PUT --data-binary "queued-message" "$BASE_URL/api/v1/files?path=$queue/enqueue" >/dev/null
   response=$(curl -fsS "$BASE_URL/api/v1/files?path=$queue/dequeue")
   assert_contains "$response" "queued-message"
+
+  echo "[backend-e2e] SQLite QueueFS concurrent dequeue smoke"
+  local sqlite_queue="/queuefs-sqlite/e2e-$(date +%s%N)"
+  curl -fsS -X POST "$BASE_URL/api/v1/directories?path=$sqlite_queue" >/dev/null
+  for i in $(seq 0 7); do
+    curl -fsS -X PUT --data-binary "sqlite-message-$i" "$BASE_URL/api/v1/files?path=$sqlite_queue/enqueue" >/dev/null
+  done
+  BASE_URL="$BASE_URL" QUEUE_PATH="$sqlite_queue" python3 - <<'PY'
+import concurrent.futures
+import json
+import os
+import urllib.parse
+import urllib.request
+
+base = os.environ["BASE_URL"]
+queue = os.environ["QUEUE_PATH"]
+
+def dequeue(_):
+    query = urllib.parse.urlencode({"path": f"{queue}/dequeue"})
+    with urllib.request.urlopen(f"{base}/api/v1/files?{query}", timeout=10) as response:
+        return response.read().decode()
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+    bodies = list(pool.map(dequeue, range(8)))
+
+messages = [json.loads(body) for body in bodies]
+data = [msg.get("data") for msg in messages]
+expected = {f"sqlite-message-{i}" for i in range(8)}
+if set(data) != expected or len(data) != len(set(data)):
+    raise SystemExit(f"unexpected SQLite QueueFS dequeue results: {data}")
+PY
+  response=$(curl -fsS "$BASE_URL/api/v1/files?path=$sqlite_queue/dequeue")
+  [[ "$response" == "{}" ]] || fail "SQLite QueueFS should be empty after concurrent dequeue, got '$response'"
 
   stop_server
 }


### PR DESCRIPTION
## Summary
- add a SQLite-specific atomic dequeue statement using `UPDATE ... RETURNING data`
- keep TiDB/MySQL on the existing transaction + `FOR UPDATE SKIP LOCKED` path
- add a default SQLite busy timeout when no busy timeout is provided
- add direct concurrent SQLite backend regression coverage and backend E2E coverage through the public HTTP file API

## Verification
- `cd agfs-server && go test ./pkg/plugins/queuefs -run TestQueueFSSQLiteConcurrentDequeueNoDuplicateDelivery -count=20 -timeout 60s` -> passed
- `cd agfs-server && go test ./pkg/plugins/queuefs -count=1` -> passed
- `cd agfs-server && go test -race ./pkg/plugins/queuefs -timeout 60s` -> passed
- `cd agfs-server && python3 scripts/run_failpoint_tests.py` -> passed
- `cd agfs-server && go test ./... -timeout 300s` -> passed
- `scripts/e2e/run-backend-e2e.sh` -> backend e2e passed, including SQLite QueueFS concurrent dequeue smoke
- `scripts/e2e/run-core-e2e.sh` -> core e2e passed
- `bash -n scripts/e2e/run-backend-e2e.sh` -> passed
- `git diff --check HEAD~1..HEAD` -> clean

## E2E coverage
Covered by `scripts/e2e/run-backend-e2e.sh`. The backend E2E mounts SQLite QueueFS at `/queuefs-sqlite`, creates a queue through the public directories API, enqueues 8 messages, concurrently dequeues through `/api/v1/files`, asserts unique delivery, then verifies the queue is empty.

Focused lower-level race coverage is `TestQueueFSSQLiteConcurrentDequeueNoDuplicateDelivery`, because the public QueueFS layer serializes operations with the plugin mutex and the original race was at the backend dequeue boundary.

## Notes
- SQLite `RETURNING` requires SQLite 3.35+; `mattn/go-sqlite3` used by this repo ships a sufficiently new SQLite version.
- The default `_busy_timeout=5000` can be tuned by callers that pass their own `_busy_timeout=` or `busy_timeout=` in the SQLite DSN.

Cross-review: @dev-2 PASS in task #17 thread.
