### PR TITLE
fix(mountablefs): invalidate handles on unmount

### DIFF
--- a/agfs-server/pkg/mountablefs/handle_test.go
+++ b/agfs-server/pkg/mountablefs/handle_test.go
@@ -1,6 +1,7 @@
 package mountablefs
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
@@ -236,5 +237,103 @@ func TestMultipleHandlesSameFile(t *testing.T) {
 		if h.Path() != "/fs/shared.txt" {
 			t.Errorf("Handle %d has wrong path: %s", i, h.Path())
 		}
+	}
+}
+
+func TestUnmountInvalidatesOpenHandles(t *testing.T) {
+	mfs := NewMountableFS(api.PoolConfig{})
+
+	plugin1 := memfs.NewMemFSPlugin()
+	if err := plugin1.Initialize(map[string]interface{}{}); err != nil {
+		t.Fatalf("Failed to initialize plugin: %v", err)
+	}
+	if err := mfs.Mount("/fs", plugin1); err != nil {
+		t.Fatalf("Failed to mount fs: %v", err)
+	}
+	if _, err := mfs.Write("/fs/open.txt", []byte("before unmount"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("Failed to seed file: %v", err)
+	}
+
+	handle, err := mfs.OpenHandle("/fs/open.txt", filesystem.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open handle: %v", err)
+	}
+	handleID := handle.ID()
+
+	if _, err := mfs.GetHandle(handleID); err != nil {
+		t.Fatalf("Expected open handle to be registered before unmount: %v", err)
+	}
+
+	if err := mfs.Unmount("/fs"); err != nil {
+		t.Fatalf("Failed to unmount fs: %v", err)
+	}
+
+	if _, err := mfs.GetHandle(handleID); !errors.Is(err, filesystem.ErrNotFound) {
+		t.Fatalf("Expected unmounted handle to be removed from registry, got %v", err)
+	}
+	if err := mfs.CloseHandle(handleID); !errors.Is(err, filesystem.ErrNotFound) {
+		t.Fatalf("Expected closing invalidated handle to return not found, got %v", err)
+	}
+	if _, err := handle.Read(make([]byte, 1)); err == nil {
+		t.Fatalf("Expected pre-unmount handle object to be closed")
+	}
+	if _, err := handle.Write([]byte("x")); err == nil {
+		t.Fatalf("Expected pre-unmount handle object to reject writes after unmount")
+	}
+}
+
+func TestUnmountOnlyInvalidatesHandlesForThatMount(t *testing.T) {
+	mfs := NewMountableFS(api.PoolConfig{})
+
+	plugin1 := memfs.NewMemFSPlugin()
+	if err := plugin1.Initialize(map[string]interface{}{}); err != nil {
+		t.Fatalf("Failed to initialize plugin1: %v", err)
+	}
+	plugin2 := memfs.NewMemFSPlugin()
+	if err := plugin2.Initialize(map[string]interface{}{}); err != nil {
+		t.Fatalf("Failed to initialize plugin2: %v", err)
+	}
+
+	if err := mfs.Mount("/fs1", plugin1); err != nil {
+		t.Fatalf("Failed to mount fs1: %v", err)
+	}
+	if err := mfs.Mount("/fs2", plugin2); err != nil {
+		t.Fatalf("Failed to mount fs2: %v", err)
+	}
+	if _, err := mfs.Write("/fs1/open.txt", []byte("from fs1"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("Failed to seed fs1 file: %v", err)
+	}
+	if _, err := mfs.Write("/fs2/open.txt", []byte("from fs2"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatalf("Failed to seed fs2 file: %v", err)
+	}
+
+	handle1, err := mfs.OpenHandle("/fs1/open.txt", filesystem.O_RDONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open fs1 handle: %v", err)
+	}
+	handle2, err := mfs.OpenHandle("/fs2/open.txt", filesystem.O_RDONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open fs2 handle: %v", err)
+	}
+	defer handle2.Close()
+
+	if err := mfs.Unmount("/fs1"); err != nil {
+		t.Fatalf("Failed to unmount fs1: %v", err)
+	}
+
+	if _, err := mfs.GetHandle(handle1.ID()); !errors.Is(err, filesystem.ErrNotFound) {
+		t.Fatalf("Expected fs1 handle to be invalidated, got %v", err)
+	}
+	if _, err := mfs.GetHandle(handle2.ID()); err != nil {
+		t.Fatalf("Expected fs2 handle to remain registered, got %v", err)
+	}
+
+	buf := make([]byte, len("from fs2"))
+	n, err := handle2.Read(buf)
+	if err != nil {
+		t.Fatalf("Expected fs2 handle to remain readable after fs1 unmount: %v", err)
+	}
+	if got := string(buf[:n]); got != "from fs2" {
+		t.Fatalf("Expected fs2 handle to read %q, got %q", "from fs2", got)
 	}
 }

--- a/agfs-server/pkg/mountablefs/mountablefs.go
+++ b/agfs-server/pkg/mountablefs/mountablefs.go
@@ -1,6 +1,7 @@
 package mountablefs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -274,6 +275,10 @@ func (mfs *MountableFS) Unmount(path string) error {
 		return fmt.Errorf("no mount at path: %s", path)
 	}
 	mount := val.(*MountPoint)
+
+	if err := mfs.closeHandlesForMount(mount); err != nil {
+		return fmt.Errorf("failed to close open handles for mount %s: %w", path, err)
+	}
 
 	// Shutdown the plugin
 	if err := mount.Plugin.Shutdown(); err != nil {
@@ -1027,6 +1032,9 @@ func (mfs *MountableFS) GetStream(path string) (interface{}, error) {
 // OpenHandle opens a file and returns a handle for stateful operations
 // This delegates to the underlying filesystem if it supports HandleFS
 func (mfs *MountableFS) OpenHandle(path string, flags filesystem.OpenFlag, mode uint32) (filesystem.FileHandle, error) {
+	mfs.mu.RLock()
+	defer mfs.mu.RUnlock()
+
 	mount, relPath, found := mfs.findMount(path)
 
 	if !found {
@@ -1059,6 +1067,7 @@ func (mfs *MountableFS) OpenHandle(path string, flags filesystem.OpenFlag, mode 
 	// Return a wrapper that uses the global ID
 	return &globalFileHandle{
 		globalID:    globalID,
+		owner:       mfs,
 		localHandle: localHandle,
 		mountPath:   mount.Path,
 		fullPath:    path,
@@ -1079,6 +1088,7 @@ func (mfs *MountableFS) GetHandle(id int64) (filesystem.FileHandle, error) {
 	// Return a wrapper with the global ID
 	return &globalFileHandle{
 		globalID:    id,
+		owner:       mfs,
 		localHandle: info.localHandle,
 		mountPath:   info.mount.Path,
 		fullPath:    info.mount.Path + info.localHandle.Path(),
@@ -1087,31 +1097,50 @@ func (mfs *MountableFS) GetHandle(id int64) (filesystem.FileHandle, error) {
 
 // CloseHandle closes a handle by its ID
 func (mfs *MountableFS) CloseHandle(id int64) error {
-	// Look up the handle info using the global ID
-	mfs.handleInfosMu.RLock()
+	mfs.handleInfosMu.Lock()
 	info, found := mfs.handleInfos[id]
-	mfs.handleInfosMu.RUnlock()
-
 	if !found {
+		mfs.handleInfosMu.Unlock()
 		return filesystem.ErrNotFound
 	}
+	delete(mfs.handleInfos, id)
+	mfs.handleInfosMu.Unlock()
 
-	// Close the underlying local handle
-	err := info.localHandle.Close()
-	if err == nil {
-		// Remove from mapping
-		mfs.handleInfosMu.Lock()
-		delete(mfs.handleInfos, id)
-		mfs.handleInfosMu.Unlock()
+	return info.localHandle.Close()
+}
+
+func (mfs *MountableFS) closeHandlesForMount(mount *MountPoint) error {
+	type handleToClose struct {
+		id     int64
+		handle filesystem.FileHandle
 	}
 
-	return err
+	var handles []handleToClose
+
+	mfs.handleInfosMu.Lock()
+	for id, info := range mfs.handleInfos {
+		if info.mount == mount {
+			handles = append(handles, handleToClose{id: id, handle: info.localHandle})
+			delete(mfs.handleInfos, id)
+		}
+	}
+	mfs.handleInfosMu.Unlock()
+
+	errs := make([]error, 0)
+	for _, item := range handles {
+		if err := item.handle.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close handle %d: %w", item.id, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // globalFileHandle wraps a local file handle with a globally unique ID
 // This prevents handle ID conflicts when multiple plugin instances are mounted
 type globalFileHandle struct {
 	globalID    int64                 // Globally unique ID assigned by MountableFS
+	owner       *MountableFS          // Registry that owns the global handle ID
 	localHandle filesystem.FileHandle // Underlying handle from the plugin
 	mountPath   string                // Mount path for this handle
 	fullPath    string                // Full path including mount point
@@ -1159,6 +1188,13 @@ func (h *globalFileHandle) Sync() error {
 
 // Close delegates to the underlying handle
 func (h *globalFileHandle) Close() error {
+	if h.owner != nil {
+		err := h.owner.CloseHandle(h.globalID)
+		if errors.Is(err, filesystem.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
 	return h.localHandle.Close()
 }
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -74,7 +74,9 @@ This focused backend gate starts real `agfs-server` processes from temporary
 configs. It asserts exact healthy and degraded readiness semantics, verifies
 `/api/v1/mounts` includes mounted and failed configured mounts, exercises the
 HTTP file API, checks request-body `413` behavior, and smokes mounted MemFS,
-QueueFS, ServerInfoFS, HelloFS, and default DevFS paths.
+QueueFS, ServerInfoFS, HelloFS, and default DevFS paths. It also opens a public
+file handle against the configured MemFS plugin and verifies the handle is
+invalidated after unmount.
 
 Useful environment overrides:
 

--- a/scripts/e2e/run-backend-e2e.sh
+++ b/scripts/e2e/run-backend-e2e.sh
@@ -325,6 +325,29 @@ PY
   response=$(curl -fsS "$BASE_URL/api/v1/files?path=$sqlite_queue/dequeue")
   [[ "$response" == "{}" ]] || fail "SQLite QueueFS should be empty after concurrent dequeue, got '$response'"
 
+  echo "[backend-e2e] unmount invalidates open handles"
+  local handle_mount="/memfs"
+  local handle_path="$handle_mount/e2e/file.txt"
+  response=$(curl -fsS -X POST "$BASE_URL/api/v1/handles/open?path=$handle_path&flags=2")
+  local handle_id
+  handle_id=$(HANDLE_OPEN_JSON="$response" python3 - <<'PY'
+import json
+import os
+
+print(json.loads(os.environ["HANDLE_OPEN_JSON"])["handle_id"])
+PY
+)
+  response=$(curl -fsS "$BASE_URL/api/v1/handles/$handle_id/read?size=7")
+  [[ "$response" == "backend" ]] || fail "open handle read returned '$response', expected 'backend'"
+  curl -fsS -X POST -H "Content-Type: application/json" \
+    --data "{\"path\":\"$handle_mount\"}" \
+    "$BASE_URL/api/v1/unmount" >/dev/null
+  code=$(http_code GET "$BASE_URL/api/v1/handles/$handle_id/read?size=7" "$TMP_DIR/handle-read-after-unmount.json")
+  [[ "$code" == "404" ]] || fail "handle read after unmount should return 404, got $code with $(cat "$TMP_DIR/handle-read-after-unmount.json")"
+  assert_contains "$(cat "$TMP_DIR/handle-read-after-unmount.json")" "not found"
+  code=$(http_code DELETE "$BASE_URL/api/v1/handles/$handle_id" "$TMP_DIR/handle-close-after-unmount.json")
+  [[ "$code" == "404" ]] || fail "handle close after unmount should return 404, got $code with $(cat "$TMP_DIR/handle-close-after-unmount.json")"
+
   stop_server
 }
 


### PR DESCRIPTION
## Summary
- invalidate and close open handles for a mount before plugin shutdown during unmount
- serialize `OpenHandle` with `Unmount` and make `CloseHandle` atomically remove registry entries before closing
- keep handles on other mounts alive and make global handle wrapper close idempotent after unmount invalidation
- add focused mountablefs regressions and public backend E2E coverage

## Verification
- `cd agfs-server && go test ./pkg/mountablefs -run 'TestUnmount.*Handle|TestGlobalHandleIDUniqueness|TestMultipleHandlesSameFile' -count=1 -v` -> passed
- `cd agfs-server && go test ./pkg/mountablefs -count=1` -> passed
- `cd agfs-server && go test -race ./pkg/mountablefs -timeout 60s` -> passed
- `cd agfs-server && go test ./... -timeout 300s` -> passed
- `scripts/e2e/run-backend-e2e.sh` -> backend e2e passed, including unmount invalidates open handles
- `scripts/e2e/run-core-e2e.sh` -> core e2e passed
- `bash -n scripts/e2e/run-backend-e2e.sh` -> passed
- `git diff --check HEAD~1..HEAD` -> clean

## E2E coverage
Covered by `scripts/e2e/run-backend-e2e.sh`. The backend E2E opens a real handle through `POST /api/v1/handles/open`, reads through it, unmounts `/memfs`, then verifies both read and close on the stale handle ID return 404 through the public handle API.

Cross-review: @dev-2 PASS in task #18 thread.
